### PR TITLE
feat(strategy): add StrategyFs adapter (closes #2)

### DIFF
--- a/homebase/src/lib/fs.ts
+++ b/homebase/src/lib/fs.ts
@@ -1,4 +1,5 @@
-// File System Access API wrapper with IndexedDB handle persistence.
+// File System Access API wrapper for the morning-ritual log directory,
+// with IndexedDB handle persistence (via ./idb).
 //
 // Homebase's substrate is real plaintext markdown on disk — same folder the
 // Tauri version used (~/Documents/homebase-log/). The user picks the
@@ -12,42 +13,9 @@
 // rule 4 (grep is the memory layer) matters more than browser breadth for
 // a personal app.
 
-const IDB_NAME = "homebase";
-const IDB_STORE = "handles";
+import { idbGet, idbSet } from "./idb";
+
 const HANDLE_KEY = "logDir";
-
-// -- IndexedDB handle persistence ----------------------------------------
-
-function openIdb(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open(IDB_NAME, 1);
-    req.onupgradeneeded = () => {
-      req.result.createObjectStore(IDB_STORE);
-    };
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
-  });
-}
-
-async function idbGet<T>(key: string): Promise<T | undefined> {
-  const db = await openIdb();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(IDB_STORE, "readonly");
-    const req = tx.objectStore(IDB_STORE).get(key);
-    req.onsuccess = () => resolve(req.result as T | undefined);
-    req.onerror = () => reject(req.error);
-  });
-}
-
-async function idbSet(key: string, value: unknown): Promise<void> {
-  const db = await openIdb();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(IDB_STORE, "readwrite");
-    tx.objectStore(IDB_STORE).put(value, key);
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-  });
-}
 
 // -- Directory handle resolution ----------------------------------------
 

--- a/homebase/src/lib/idb.ts
+++ b/homebase/src/lib/idb.ts
@@ -1,0 +1,40 @@
+// Tiny IndexedDB wrapper for "save one value, look it up by string key."
+//
+// Both the morning-ritual log directory handle (fs.ts) and the strategy
+// directory handle (strategy-fs.ts) need this same shape: persist a
+// FileSystemDirectoryHandle so the user only picks the folder once. This
+// module exists so that pattern lives in exactly one place.
+
+const IDB_NAME = "homebase";
+const IDB_STORE = "handles";
+
+function open(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(IDB_NAME, 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(IDB_STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function idbGet<T>(key: string): Promise<T | undefined> {
+  const db = await open();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, "readonly");
+    const req = tx.objectStore(IDB_STORE).get(key);
+    req.onsuccess = () => resolve(req.result as T | undefined);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function idbSet(key: string, value: unknown): Promise<void> {
+  const db = await open();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(IDB_STORE, "readwrite");
+    tx.objectStore(IDB_STORE).put(value, key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}

--- a/homebase/src/lib/strategy-fs.test.ts
+++ b/homebase/src/lib/strategy-fs.test.ts
@@ -1,0 +1,80 @@
+// Tests for StrategyFs run against the in-memory fake. The fake matches
+// production semantics exactly (the fake is the testable surface; the
+// production path adds FSAccess + IDB plumbing tested by manual smoke
+// during the first-run permission flow).
+
+import { describe, expect, it } from "vite-plus/test";
+import { createFakeStrategyFs } from "./strategy-fs";
+
+describe("createFakeStrategyFs", () => {
+  it("returns null for a missing file", async () => {
+    const fs = createFakeStrategyFs();
+    expect(await fs.read("month-2026-04.md")).toBeNull();
+  });
+
+  it("write then read roundtrips content verbatim", async () => {
+    const fs = createFakeStrategyFs();
+    await fs.write("year-2026.md", "# 2026\nGoals.");
+    expect(await fs.read("year-2026.md")).toBe("# 2026\nGoals.");
+  });
+
+  it("write overwrites existing content", async () => {
+    const fs = createFakeStrategyFs({ "values.md": "old" });
+    await fs.write("values.md", "new");
+    expect(await fs.read("values.md")).toBe("new");
+  });
+
+  it("exists reflects current state", async () => {
+    const fs = createFakeStrategyFs({ "year-2026.md": "" });
+    expect(await fs.exists("year-2026.md")).toBe(true);
+    expect(await fs.exists("year-2025.md")).toBe(false);
+    await fs.write("year-2025.md", "");
+    expect(await fs.exists("year-2025.md")).toBe(true);
+  });
+
+  it("list filters by prefix", async () => {
+    const fs = createFakeStrategyFs({
+      "month-2026-04.md": "",
+      "month-2026-03.md": "",
+      "year-2026.md": "",
+      "values.md": "",
+    });
+    expect(await fs.list("month-")).toEqual(["month-2026-04.md", "month-2026-03.md"]);
+    expect(await fs.list("year-")).toEqual(["year-2026.md"]);
+  });
+
+  it("list returns names sorted lexicographically descending (most recent first)", async () => {
+    const fs = createFakeStrategyFs({
+      "month-2026-01.md": "",
+      "month-2026-12.md": "",
+      "month-2026-06.md": "",
+      "month-2025-11.md": "",
+    });
+    expect(await fs.list("month-")).toEqual([
+      "month-2026-12.md",
+      "month-2026-06.md",
+      "month-2026-01.md",
+      "month-2025-11.md",
+    ]);
+  });
+
+  it("list returns empty array when no files match the prefix", async () => {
+    const fs = createFakeStrategyFs({ "values.md": "" });
+    expect(await fs.list("month-")).toEqual([]);
+  });
+
+  it("init is a no-op for the fake (production needs it; fake doesn't)", async () => {
+    const fs = createFakeStrategyFs();
+    await expect(fs.init()).resolves.toBeUndefined();
+  });
+
+  it("seeded fake exposes initial files", async () => {
+    const fs = createFakeStrategyFs({
+      "values.md": "courage, curiosity, compassion",
+      "year-2026.md": "ship Casr",
+    });
+    expect(await fs.read("values.md")).toBe("courage, curiosity, compassion");
+    expect(await fs.read("year-2026.md")).toBe("ship Casr");
+    expect(await fs.list("")).toEqual(["year-2026.md", "values.md"]);
+  });
+});

--- a/homebase/src/lib/strategy-fs.ts
+++ b/homebase/src/lib/strategy-fs.ts
@@ -1,0 +1,210 @@
+// File System Access API wrapper for the strategy directory.
+//
+// Mirrors the log-directory pattern in ./fs but for ~/Documents/homebase-strategy/.
+// Two directories deliberately stay separate so strategy can be put under
+// version control without dragging the day log in (see active-plan.md §4.5).
+//
+// This module exports two implementations of the same shape:
+//
+//   - StrategyFs           — production singleton, real FSAccess + IDB
+//   - createFakeStrategyFs — in-memory factory, used by this module's tests
+//                            and by downstream tests (CarryOverResolver,
+//                            StrategyStore) that need a writable fake fs
+
+import { idbGet, idbSet } from "./idb";
+
+const HANDLE_KEY = "strategyDir";
+
+export interface StrategyFsApi {
+  /**
+   * Bootstrap the singleton with the saved directory handle, if permission
+   * is still granted. Returns silently if so. Throws if no handle is saved
+   * or permission was revoked — callers (the permission gate) should handle
+   * by re-prompting via pickStrategyDir().
+   */
+  init(): Promise<void>;
+  /** Read a single file. Returns null when missing; throws on real errors. */
+  read(filename: string): Promise<string | null>;
+  /** Write a file (creates if missing). */
+  write(filename: string, content: string): Promise<void>;
+  /**
+   * List filenames in the directory whose name starts with `prefix`.
+   * Sorted **lexicographically descending** (most recent first by ISO key —
+   * `month-2026-04.md` before `month-2026-03.md`).
+   */
+  list(prefix: string): Promise<string[]>;
+  exists(filename: string): Promise<boolean>;
+}
+
+// -- Directory handle resolution ----------------------------------------
+
+let cachedDir: FileSystemDirectoryHandle | null = null;
+
+/** True if FSAccess is supported. Same check as fs.fsaSupported. */
+export function fsaSupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof (window as unknown as { showDirectoryPicker?: unknown }).showDirectoryPicker ===
+      "function"
+  );
+}
+
+/**
+ * Return the saved strategy directory handle if permission is still granted,
+ * else null. Never prompts.
+ */
+export async function getSavedStrategyDir(): Promise<FileSystemDirectoryHandle | null> {
+  if (cachedDir) {
+    const ok = await verifyPermission(cachedDir);
+    return ok ? cachedDir : null;
+  }
+  const saved = await idbGet<FileSystemDirectoryHandle>(HANDLE_KEY);
+  if (!saved) return null;
+  const ok = await verifyPermission(saved);
+  if (!ok) return null;
+  cachedDir = saved;
+  return saved;
+}
+
+/** Prompt user to pick the strategy directory. Must be from a user gesture. */
+export async function pickStrategyDir(): Promise<FileSystemDirectoryHandle> {
+  const handle = await window.showDirectoryPicker({ mode: "readwrite" });
+  await idbSet(HANDLE_KEY, handle);
+  cachedDir = handle;
+  return handle;
+}
+
+/** Re-request permission on the stored handle. Must be from a user gesture. */
+export async function requestStrategyDirPermission(): Promise<FileSystemDirectoryHandle | null> {
+  const saved = await idbGet<FileSystemDirectoryHandle>(HANDLE_KEY);
+  if (!saved) return null;
+  const perm = await saved.requestPermission({ mode: "readwrite" });
+  if (perm !== "granted") return null;
+  cachedDir = saved;
+  return saved;
+}
+
+async function verifyPermission(handle: FileSystemDirectoryHandle): Promise<boolean> {
+  const status = await handle.queryPermission({ mode: "readwrite" });
+  return status === "granted";
+}
+
+function dirOrThrow(): FileSystemDirectoryHandle {
+  if (!cachedDir) {
+    throw new Error(
+      "strategy directory handle not initialized — the permission gate should have blocked app render",
+    );
+  }
+  return cachedDir;
+}
+
+// -- File operations on a handle (shared by production + tests via fake) -
+
+async function readFromDir(dir: FileSystemDirectoryHandle, name: string): Promise<string | null> {
+  try {
+    const file = await dir.getFileHandle(name);
+    const blob = await file.getFile();
+    return blob.text();
+  } catch (err) {
+    if (isNotFound(err)) return null;
+    throw err;
+  }
+}
+
+async function writeToDir(
+  dir: FileSystemDirectoryHandle,
+  name: string,
+  content: string,
+): Promise<void> {
+  const file = await dir.getFileHandle(name, { create: true });
+  const writable = await file.createWritable();
+  await writable.write(content);
+  await writable.close();
+}
+
+async function listInDir(dir: FileSystemDirectoryHandle, prefix: string): Promise<string[]> {
+  const names: string[] = [];
+  for await (const [name, handle] of dir.entries()) {
+    if (handle.kind !== "file") continue;
+    if (!name.startsWith(prefix)) continue;
+    names.push(name);
+  }
+  // Lexicographic descending — most recent ISO key first.
+  return names.sort((a, b) => (a < b ? 1 : a > b ? -1 : 0));
+}
+
+async function existsInDir(dir: FileSystemDirectoryHandle, name: string): Promise<boolean> {
+  try {
+    await dir.getFileHandle(name);
+    return true;
+  } catch (err) {
+    if (isNotFound(err)) return false;
+    throw err;
+  }
+}
+
+function isNotFound(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "NotFoundError";
+}
+
+// -- Production singleton -----------------------------------------------
+
+export const StrategyFs: StrategyFsApi = {
+  async init() {
+    if (cachedDir) return;
+    const saved = await getSavedStrategyDir();
+    if (!saved) {
+      throw new Error("strategy directory handle missing or permission revoked");
+    }
+    cachedDir = saved;
+  },
+  async read(filename) {
+    return readFromDir(dirOrThrow(), filename);
+  },
+  async write(filename, content) {
+    return writeToDir(dirOrThrow(), filename, content);
+  },
+  async list(prefix) {
+    return listInDir(dirOrThrow(), prefix);
+  },
+  async exists(filename) {
+    return existsInDir(dirOrThrow(), filename);
+  },
+};
+
+// -- Fake (in-memory) for tests -----------------------------------------
+
+/**
+ * Build an in-memory `StrategyFsApi` for tests. Pass an optional initial
+ * map of filename → content to seed the fake.
+ *
+ * The fake matches production semantics exactly:
+ *   - read() returns null for missing files
+ *   - write() creates or overwrites
+ *   - list(prefix) returns names sorted descending
+ *   - exists() reflects current state
+ */
+export function createFakeStrategyFs(initial: Record<string, string> = {}): StrategyFsApi {
+  const files = new Map<string, string>(Object.entries(initial));
+  return {
+    async init() {
+      // No-op for the fake; nothing to bootstrap.
+    },
+    async read(filename) {
+      return files.has(filename) ? (files.get(filename) ?? null) : null;
+    },
+    async write(filename, content) {
+      files.set(filename, content);
+    },
+    async list(prefix) {
+      const matches: string[] = [];
+      for (const name of files.keys()) {
+        if (name.startsWith(prefix)) matches.push(name);
+      }
+      return matches.sort((a, b) => (a < b ? 1 : a > b ? -1 : 0));
+    },
+    async exists(filename) {
+      return files.has(filename);
+    },
+  };
+}


### PR DESCRIPTION
Implements **#2 — StrategyFs adapter for homebase-strategy directory**.

## What this PR does

Two coordinated changes:

1. **Refactor**: extracts shared IndexedDB helpers from `fs.ts` into a new `lib/idb.ts`. Behavior unchanged; just paying down duplication before adding the second consumer.
2. **Feature**: adds `lib/strategy-fs.ts` — File System Access API wrapper for the new `~/Documents/homebase-strategy/` directory, separate from the existing log directory per active-plan.md §4.5.

Public surface mirrors the M2 spec from the plan:
\`\`\`ts
StrategyFs.init(): Promise<void>
StrategyFs.read(filename): Promise<string | null>
StrategyFs.write(filename, content): Promise<void>
StrategyFs.list(prefix): Promise<string[]>     // sorted lex DESC (most recent first)
StrategyFs.exists(filename): Promise<boolean>
\`\`\`

Plus an exported `createFakeStrategyFs(initial?)` factory — in-memory implementation with matching semantics. This is what the module's own tests run against, and what `CarryOverResolver` (#4) and `StrategyStore` (#5) will use as their fs dependency.

## Acceptance criteria

- [x] Module exports `StrategyFs` with init/read/write/list/exists
- [x] FSAccess API + IDB handle persistence (same pattern as existing log handle, now shared via `lib/idb.ts`)
- [x] `read()` returns `null` for missing files, throws for permission/other errors
- [x] `write()` creates if missing, overwrites if present
- [x] `list(prefix)` returns filenames matching prefix, sorted lexicographically descending
- [x] In-memory fake implementation provided (`createFakeStrategyFs`)
- [x] Unit tests: read/write/exists roundtrip, list with prefix, list sort order, missing-file null

## Test plan

- [x] `pnpm test` — 31 passing (9 new StrategyFs + 19 PeriodKey + 3 slot tests)
- [x] `pnpm check` — 0 errors, 0 warnings across 47 files
- [ ] CI green