### PR TITLE
feat(strategy): add CarryOverResolver (closes #4)

### DIFF
--- a/homebase/src/lib/carry-over-resolver.test.ts
+++ b/homebase/src/lib/carry-over-resolver.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vite-plus/test";
+import { CarryOverResolver } from "./carry-over-resolver";
+import { createFakeStrategyFs } from "./strategy-fs";
+
+describe("CarryOverResolver.resolve", () => {
+  it("returns null when no prior files exist (very first entry)", async () => {
+    const fs = createFakeStrategyFs();
+    expect(await CarryOverResolver.resolve(fs, "month", "2026-04")).toBeNull();
+    expect(await CarryOverResolver.resolve(fs, "year", "2026")).toBeNull();
+    expect(await CarryOverResolver.resolve(fs, "week", "2026-W17")).toBeNull();
+  });
+
+  it("returns prior period's content when the immediate prior exists", async () => {
+    const fs = createFakeStrategyFs({
+      "month-2026-03.md": "March goals.",
+    });
+    const result = await CarryOverResolver.resolve(fs, "month", "2026-04");
+    expect(result).toEqual({ content: "March goals.", sourcePeriod: "2026-03" });
+  });
+
+  it("falls back to the most recent existing file when there's a gap", async () => {
+    // April was skipped — May expands and should pull from March.
+    const fs = createFakeStrategyFs({
+      "month-2026-03.md": "March goals.",
+      "month-2026-01.md": "January goals.",
+    });
+    const result = await CarryOverResolver.resolve(fs, "month", "2026-05");
+    expect(result).toEqual({ content: "March goals.", sourcePeriod: "2026-03" });
+  });
+
+  it("does not pull from a file at or after the target period", async () => {
+    // Future-dated files (somehow created) shouldn't leak backwards.
+    const fs = createFakeStrategyFs({
+      "month-2026-05.md": "May (already exists, irrelevant).",
+      "month-2026-06.md": "June (future-ish).",
+    });
+    const result = await CarryOverResolver.resolve(fs, "month", "2026-04");
+    expect(result).toBeNull();
+  });
+
+  it("handles year-rollover for week horizon", async () => {
+    // Prior of 2026-W01 is 2025-W52 (52-week year).
+    const fs = createFakeStrategyFs({
+      "week-2025-W52.md": "Last week of 2025.",
+    });
+    const result = await CarryOverResolver.resolve(fs, "week", "2026-W01");
+    expect(result).toEqual({ content: "Last week of 2025.", sourcePeriod: "2025-W52" });
+  });
+
+  it("handles year-rollover for month horizon (Jan → prior Dec)", async () => {
+    const fs = createFakeStrategyFs({
+      "month-2025-12.md": "December.",
+    });
+    const result = await CarryOverResolver.resolve(fs, "month", "2026-01");
+    expect(result).toEqual({ content: "December.", sourcePeriod: "2025-12" });
+  });
+
+  it("handles year horizon decrement", async () => {
+    const fs = createFakeStrategyFs({
+      "year-2025.md": "2025 plan.",
+    });
+    const result = await CarryOverResolver.resolve(fs, "year", "2026");
+    expect(result).toEqual({ content: "2025 plan.", sourcePeriod: "2025" });
+  });
+
+  it("returns content from prior even when other unrelated files exist", async () => {
+    const fs = createFakeStrategyFs({
+      "values.md": "courage, curiosity",
+      "life-goals.md": "ship Casr",
+      "year-2026.md": "2026.",
+      "month-2026-03.md": "March.",
+    });
+    const result = await CarryOverResolver.resolve(fs, "month", "2026-04");
+    expect(result?.content).toBe("March.");
+  });
+
+  it("throws for persistent horizons (no period to roll back from)", async () => {
+    const fs = createFakeStrategyFs();
+    await expect(CarryOverResolver.resolve(fs, "life-values", "anything")).rejects.toThrow();
+    await expect(CarryOverResolver.resolve(fs, "life-goals", "anything")).rejects.toThrow();
+  });
+
+  it("returns the prior even when content is empty string (file exists, empty body)", async () => {
+    const fs = createFakeStrategyFs({
+      "month-2026-03.md": "",
+    });
+    const result = await CarryOverResolver.resolve(fs, "month", "2026-04");
+    expect(result).toEqual({ content: "", sourcePeriod: "2026-03" });
+  });
+});

--- a/homebase/src/lib/carry-over-resolver.ts
+++ b/homebase/src/lib/carry-over-resolver.ts
@@ -1,0 +1,95 @@
+// CarryOverResolver — when a user expands a time-bound horizon for a period
+// that has no file yet (May 2026 monthly when only April 2026 exists),
+// this resolver returns the content to pre-load into the editor along
+// with the actual source period, so the carry-over banner can show
+// "Carried from April 2026" (or "Carried from March 2026" if April was
+// skipped).
+//
+// Two-step lookup, per the strategic-layer plan §F3 / §4.6:
+//
+//   1. Direct: read the file for prior period (computed via PeriodKey.prior)
+//   2. Fallback: list all files for the horizon, take the lexicographically
+//      greatest filename strictly less than the target — handles gaps
+//      (April skipped → May resolves March)
+//
+// Persistent horizons (life-values, life-goals) have no carry-over by design
+// (single file, no prior period); calling resolve() with them throws.
+
+import { PeriodKey, type Horizon } from "./period-key";
+import type { StrategyFsApi } from "./strategy-fs";
+
+export type CarryOver = { content: string; sourcePeriod: string };
+
+const TIME_BOUND_HORIZONS: ReadonlySet<Horizon> = new Set(["year", "month", "week"]);
+
+/**
+ * Filename for a time-bound horizon at a given period key, e.g.
+ * `year-2026.md`, `month-2026-04.md`, `week-2026-W17.md`.
+ */
+function filename(horizon: Horizon, periodKey: string): string {
+  return `${horizon}-${periodKey}.md`;
+}
+
+/**
+ * Filename prefix for a time-bound horizon (used by list()), e.g.
+ * `month-` matches `month-2026-04.md`, `month-2026-03.md`, etc.
+ */
+function prefix(horizon: Horizon): string {
+  return `${horizon}-`;
+}
+
+/**
+ * Extract the period key from a filename produced by `filename()` above.
+ * `month-2026-04.md` → `2026-04`.
+ */
+function periodKeyOf(horizon: Horizon, file: string): string {
+  return file.slice(prefix(horizon).length, -".md".length);
+}
+
+export const CarryOverResolver = {
+  /**
+   * Resolve carry-over for `targetPeriod` of `horizon`.
+   *
+   * Returns the prior period's content (and the actual sourcePeriod)
+   * when a prior file exists, falling back to the most recent existing
+   * file before targetPeriod when there's a gap. Returns null when no
+   * prior file exists at all (very first entry ever for this horizon).
+   *
+   * The caller is responsible for not calling this when the target file
+   * already exists — this function does not check that. Carry-over is
+   * a *first-time-entering-a-new-period* concern.
+   */
+  async resolve(
+    fs: StrategyFsApi,
+    horizon: Horizon,
+    targetPeriod: string,
+  ): Promise<CarryOver | null> {
+    if (!TIME_BOUND_HORIZONS.has(horizon)) {
+      throw new Error(`CarryOverResolver.resolve is undefined for persistent horizon: ${horizon}`);
+    }
+
+    // Step 1: try the direct prior period.
+    const priorKey = PeriodKey.prior(horizon, targetPeriod);
+    const priorContent = await fs.read(filename(horizon, priorKey));
+    if (priorContent !== null) {
+      return { content: priorContent, sourcePeriod: priorKey };
+    }
+
+    // Step 2: fall back to lex-greatest existing file strictly less than target.
+    // StrategyFs.list returns descending, so the first entry whose period_key
+    // is < targetPeriod is the most recent prior.
+    const all = await fs.list(prefix(horizon));
+    const targetFile = filename(horizon, targetPeriod);
+    for (const file of all) {
+      if (file < targetFile) {
+        const sourceKey = periodKeyOf(horizon, file);
+        const content = await fs.read(file);
+        if (content !== null) {
+          return { content, sourcePeriod: sourceKey };
+        }
+      }
+    }
+
+    return null;
+  },
+};


### PR DESCRIPTION
Implements **#4 — CarryOverResolver with fixture-driven tests**. Two-step lookup (direct prior + lex-greatest fallback for gaps). Takes StrategyFs as a parameter so tests use the in-memory fake from #2 with zero mocking. 10 tests covering: no-history null, direct prior hit, gap fallback (April skipped → May resolves March), future-dated files don't leak backwards, year-rollover for week (W01 → prior W52), month (Jan → prior Dec), and year (decrement), persistent-horizon throw, and empty-string content as a valid prior.

41 tests pass, 0 lint/format errors. CI green expected.