### PR TITLE
feat(strategy): add StrategyStore Zustand slice (closes #5)

### DIFF
--- a/homebase/src/store/strategy.test.ts
+++ b/homebase/src/store/strategy.test.ts
@@ -1,0 +1,132 @@
+// StrategyStore tests — exercised via the factory bound to an in-memory
+// fake StrategyFs. We never hit the production singleton in tests because
+// it's bound to FSAccess which doesn't exist in jsdom.
+
+import { describe, expect, it } from "vite-plus/test";
+import { createFakeStrategyFs } from "../lib/strategy-fs";
+import { createStrategyStore } from "./strategy";
+
+describe("StrategyStore", () => {
+  it("seeds all six horizons with idle defaults on init", () => {
+    const store = createStrategyStore(createFakeStrategyFs());
+    const { rows } = store.getState();
+    for (const h of ["life-values", "life-goals", "year", "month", "week"] as const) {
+      expect(rows[h]).toMatchObject({
+        expanded: false,
+        content: "",
+        carryOver: null,
+        saveStatus: "idle",
+        dirty: false,
+        loaded: false,
+      });
+    }
+  });
+
+  it("expandRow loads the file content when the file exists", async () => {
+    const store = createStrategyStore(createFakeStrategyFs({ "values.md": "courage, curiosity" }));
+    await store.getState().expandRow("life-values");
+    const row = store.getState().rows["life-values"];
+    expect(row.content).toBe("courage, curiosity");
+    expect(row.expanded).toBe(true);
+    expect(row.loaded).toBe(true);
+    expect(row.carryOver).toBeNull();
+    expect(row.dirty).toBe(false);
+  });
+
+  it("expandRow on time-bound horizon with no current file pulls carry-over", async () => {
+    // Find what the prior period of the current month is, so we can seed it.
+    // Easier: pre-seed any prior month so the resolver's gap-fallback finds it.
+    const store = createStrategyStore(createFakeStrategyFs({ "month-2020-01.md": "ancient" }));
+    await store.getState().expandRow("month");
+    const row = store.getState().rows["month"];
+    expect(row.content).toBe("ancient");
+    expect(row.carryOver).toEqual({ content: "ancient", sourcePeriod: "2020-01" });
+    expect(row.dirty).toBe(true); // carrying content counts as a buffer to save
+  });
+
+  it("expandRow on time-bound horizon with no history at all leaves empty + no banner", async () => {
+    const store = createStrategyStore(createFakeStrategyFs());
+    await store.getState().expandRow("year");
+    const row = store.getState().rows.year;
+    expect(row.content).toBe("");
+    expect(row.carryOver).toBeNull();
+    expect(row.dirty).toBe(false);
+  });
+
+  it("expandRow re-expand without changes does not re-fetch (loaded short-circuit)", async () => {
+    const fs = createFakeStrategyFs({ "values.md": "v1" });
+    const store = createStrategyStore(fs);
+    await store.getState().expandRow("life-values");
+    // Mutate the underlying file; if expandRow re-reads, content would change.
+    await fs.write("values.md", "v2");
+    store.getState().collapseRow("life-values");
+    await store.getState().expandRow("life-values");
+    expect(store.getState().rows["life-values"].content).toBe("v1");
+  });
+
+  it("setContent updates content, marks dirty, dismisses carry-over banner", async () => {
+    const store = createStrategyStore(createFakeStrategyFs({ "month-2020-01.md": "ancient" }));
+    await store.getState().expandRow("month");
+    expect(store.getState().rows.month.carryOver).not.toBeNull();
+    store.getState().setContent("month", "edited");
+    const row = store.getState().rows.month;
+    expect(row.content).toBe("edited");
+    expect(row.dirty).toBe(true);
+    expect(row.carryOver).toBeNull();
+  });
+
+  it("clearCarryOver empties content + dismisses banner + resets loaded for re-trigger", async () => {
+    const store = createStrategyStore(createFakeStrategyFs({ "month-2020-01.md": "ancient" }));
+    await store.getState().expandRow("month");
+    expect(store.getState().rows.month.carryOver).not.toBeNull();
+
+    store.getState().clearCarryOver("month");
+    let row = store.getState().rows.month;
+    expect(row.content).toBe("");
+    expect(row.carryOver).toBeNull();
+    expect(row.loaded).toBe(false);
+
+    // Re-trigger by re-expanding: resolver should re-pull the same carry-over.
+    await store.getState().expandRow("month");
+    row = store.getState().rows.month;
+    expect(row.content).toBe("ancient");
+    expect(row.carryOver).toEqual({ content: "ancient", sourcePeriod: "2020-01" });
+  });
+
+  it("flush writes content to fs, transitions saveStatus, clears dirty", async () => {
+    const fs = createFakeStrategyFs();
+    const store = createStrategyStore(fs);
+    await store.getState().expandRow("life-values");
+    store.getState().setContent("life-values", "courage");
+    expect(store.getState().rows["life-values"].dirty).toBe(true);
+
+    await store.getState().flush("life-values");
+
+    expect(await fs.read("values.md")).toBe("courage");
+    const row = store.getState().rows["life-values"];
+    expect(row.dirty).toBe(false);
+    expect(row.saveStatus).toBe("saved");
+  });
+
+  it("flush is a no-op when not dirty", async () => {
+    const fs = createFakeStrategyFs();
+    const store = createStrategyStore(fs);
+    await store.getState().expandRow("life-values");
+
+    await store.getState().flush("life-values");
+    expect(await fs.exists("values.md")).toBe(false);
+    expect(store.getState().rows["life-values"].saveStatus).toBe("idle");
+  });
+
+  it("resetSaveStatus brings saveStatus back to idle (consumer-driven settle)", async () => {
+    const fs = createFakeStrategyFs();
+    const store = createStrategyStore(fs);
+    await store.getState().expandRow("life-values");
+    store.getState().setContent("life-values", "x");
+    await store.getState().flush("life-values");
+    expect(store.getState().rows["life-values"].saveStatus).toBe("saved");
+
+    store.getState().resetSaveStatus("life-values");
+    expect(store.getState().rows["life-values"].saveStatus).toBe("idle");
+  });
+});

--- a/homebase/src/store/strategy.ts
+++ b/homebase/src/store/strategy.ts
@@ -1,0 +1,204 @@
+// Zustand store for the strategic accordion.
+//
+// State shape per row: { expanded, content, carryOver, saveStatus, dirty, loaded }.
+// Six horizons are seeded at idle defaults on initialization; the row's
+// content + carryOver are populated lazily on first expand via expandRow.
+//
+// The store is built via a factory so tests can pass an in-memory fake
+// StrategyFs. Production callers use `useStrategyStore`, the singleton
+// built from the production StrategyFs.
+
+import { create, type StoreApi, type UseBoundStore } from "zustand";
+import { CarryOverResolver, type CarryOver } from "../lib/carry-over-resolver";
+import { PeriodKey, type Horizon } from "../lib/period-key";
+import { StrategyFs, type StrategyFsApi } from "../lib/strategy-fs";
+
+export type SaveStatus = "idle" | "saving" | "saved";
+
+export interface RowState {
+  expanded: boolean;
+  content: string;
+  carryOver: CarryOver | null;
+  saveStatus: SaveStatus;
+  dirty: boolean;
+  loaded: boolean;
+}
+
+export interface StrategyState {
+  rows: Record<Horizon, RowState>;
+  expandRow: (horizon: Horizon) => Promise<void>;
+  collapseRow: (horizon: Horizon) => void;
+  setContent: (horizon: Horizon, content: string) => void;
+  clearCarryOver: (horizon: Horizon) => void;
+  flush: (horizon: Horizon) => Promise<void>;
+  resetSaveStatus: (horizon: Horizon) => void;
+}
+
+const HORIZONS: readonly Horizon[] = ["life-values", "life-goals", "year", "month", "week"];
+
+function defaultRow(): RowState {
+  return {
+    expanded: false,
+    content: "",
+    carryOver: null,
+    saveStatus: "idle",
+    dirty: false,
+    loaded: false,
+  };
+}
+
+function defaultRows(): Record<Horizon, RowState> {
+  const rows = {} as Record<Horizon, RowState>;
+  for (const h of HORIZONS) rows[h] = defaultRow();
+  return rows;
+}
+
+/**
+ * Filename for a horizon. Persistent horizons use a fixed filename;
+ * time-bound horizons compute the current period via PeriodKey at call
+ * time (so a row expanded after midnight on Monday targets the new week).
+ */
+function filenameFor(horizon: Horizon, now: Date = new Date()): string {
+  if (horizon === "life-values") return "values.md";
+  if (horizon === "life-goals") return "life-goals.md";
+  const key = PeriodKey.current(horizon, now);
+  if (!key) {
+    // PeriodKey.current returns null only for persistent horizons, both
+    // handled above. This branch is unreachable at runtime.
+    throw new Error(`unexpected null period_key for time-bound horizon: ${horizon}`);
+  }
+  return `${horizon}-${key}.md`;
+}
+
+/**
+ * Build a Strategy store backed by `fs`. Production uses the real
+ * StrategyFs singleton; tests pass createFakeStrategyFs(...).
+ */
+export function createStrategyStore(fs: StrategyFsApi): UseBoundStore<StoreApi<StrategyState>> {
+  return create<StrategyState>()((set, get) => ({
+    rows: defaultRows(),
+
+    expandRow: async (horizon) => {
+      const row = get().rows[horizon];
+
+      // Already loaded? Just open it; no re-fetch.
+      if (row.loaded) {
+        set((s) => ({
+          rows: { ...s.rows, [horizon]: { ...s.rows[horizon], expanded: true } },
+        }));
+        return;
+      }
+
+      // First-time expand: read the file. If it exists, that's the content.
+      // If it doesn't exist and the horizon is time-bound, run the resolver
+      // to find a carry-over candidate.
+      const file = filenameFor(horizon);
+      const existing = await fs.read(file);
+
+      let content = "";
+      let carryOver: CarryOver | null = null;
+      if (existing !== null) {
+        content = existing;
+      } else if (horizon === "year" || horizon === "month" || horizon === "week") {
+        const targetPeriod = PeriodKey.current(horizon);
+        if (targetPeriod) {
+          const co = await CarryOverResolver.resolve(fs, horizon, targetPeriod);
+          if (co) {
+            content = co.content;
+            carryOver = co;
+          }
+        }
+      }
+
+      set((s) => ({
+        rows: {
+          ...s.rows,
+          [horizon]: {
+            ...s.rows[horizon],
+            expanded: true,
+            content,
+            carryOver,
+            loaded: true,
+            // Carrying content into a never-saved buffer counts as dirty:
+            // user has unsaved content (the prior period's body) sitting in
+            // a file that doesn't exist yet. First flush writes it and the
+            // banner dismisses naturally on first edit.
+            dirty: carryOver !== null,
+          },
+        },
+      }));
+    },
+
+    collapseRow: (horizon) => {
+      set((s) => ({
+        rows: { ...s.rows, [horizon]: { ...s.rows[horizon], expanded: false } },
+      }));
+    },
+
+    setContent: (horizon, content) => {
+      set((s) => ({
+        rows: {
+          ...s.rows,
+          [horizon]: {
+            ...s.rows[horizon],
+            content,
+            dirty: true,
+            // First edit dismisses the carry-over banner — the user has
+            // engaged with the content, the "this is carried" affordance is
+            // no longer needed.
+            carryOver: null,
+          },
+        },
+      }));
+    },
+
+    clearCarryOver: (horizon) => {
+      // Empty the buffer and reset the banner. `loaded: false` so the next
+      // expand re-runs the resolver — that's the documented "re-trigger by
+      // collapsing and re-expanding" behavior from plan §F3.
+      set((s) => ({
+        rows: {
+          ...s.rows,
+          [horizon]: {
+            ...s.rows[horizon],
+            content: "",
+            carryOver: null,
+            dirty: false,
+            loaded: false,
+          },
+        },
+      }));
+    },
+
+    flush: async (horizon) => {
+      const row = get().rows[horizon];
+      if (!row.dirty) return;
+      set((s) => ({
+        rows: { ...s.rows, [horizon]: { ...s.rows[horizon], saveStatus: "saving" } },
+      }));
+      try {
+        await fs.write(filenameFor(horizon), row.content);
+        set((s) => ({
+          rows: {
+            ...s.rows,
+            [horizon]: { ...s.rows[horizon], saveStatus: "saved", dirty: false },
+          },
+        }));
+      } catch (err) {
+        set((s) => ({
+          rows: { ...s.rows, [horizon]: { ...s.rows[horizon], saveStatus: "idle" } },
+        }));
+        throw err;
+      }
+    },
+
+    resetSaveStatus: (horizon) => {
+      set((s) => ({
+        rows: { ...s.rows, [horizon]: { ...s.rows[horizon], saveStatus: "idle" } },
+      }));
+    },
+  }));
+}
+
+/** Production singleton, bound to the real StrategyFs. */
+export const useStrategyStore = createStrategyStore(StrategyFs);


### PR DESCRIPTION
Implements **#5**. Factory-pattern Zustand store; production singleton bound to real StrategyFs, tests use the in-memory fake from #2. State per row: expanded/content/carryOver/saveStatus/dirty/loaded. 10 tests covering all six actions and load/re-load/clear interactions.

51 tests pass, 0 lint/format errors.