### PR TITLE
feat(strategy): wire autosave + save indicator (closes #7)

### DIFF
--- a/homebase/src/components/SaveIndicator.test.tsx
+++ b/homebase/src/components/SaveIndicator.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { SaveIndicator } from "./SaveIndicator";
+
+describe("SaveIndicator", () => {
+  it("renders nothing for status='idle'", () => {
+    const { container } = render(<SaveIndicator status="idle" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a pulsing dot for status='saving'", () => {
+    const { container } = render(<SaveIndicator status="saving" />);
+    const dot = container.firstChild as HTMLElement;
+    expect(dot).not.toBeNull();
+    expect(dot.classList.contains("save-indicator-pulse")).toBe(true);
+    expect(screen.getByLabelText("Saving")).toBe(dot);
+  });
+
+  it("renders a non-animated terracotta dot for status='saved'", () => {
+    const { container } = render(<SaveIndicator status="saved" />);
+    const dot = container.firstChild as HTMLElement;
+    expect(dot.classList.contains("save-indicator-pulse")).toBe(false);
+    expect(screen.getByLabelText("Saved")).toBe(dot);
+  });
+
+  it("renders a darker dot with explanatory tooltip for status='error'", () => {
+    const { container } = render(<SaveIndicator status="error" />);
+    const dot = container.firstChild as HTMLElement;
+    expect(dot.classList.contains("save-indicator-pulse")).toBe(false);
+    expect(dot.getAttribute("title")).toMatch(/save failed/i);
+    expect(dot.getAttribute("aria-label")).toMatch(/save failed/i);
+  });
+});

--- a/homebase/src/components/SaveIndicator.tsx
+++ b/homebase/src/components/SaveIndicator.tsx
@@ -1,0 +1,51 @@
+// SaveIndicator — a 6px dot that pulses while saving and settles to a
+// terracotta dot when saved (per the strategic-layer mock at
+// .llm/design-strategic-layer/mock.html .save-indicator). Renders nothing
+// when status is "idle". On "error", renders a darker terracotta dot
+// without animation; the dot stays visible until the next successful save.
+//
+// Color values come from the route's CSS variables (--ink-ghost,
+// --terracotta) so the indicator picks up the warm-cream Lapham palette
+// when the strategic layer mounts.
+
+import type { SaveStatus } from "../store/strategy";
+
+interface SaveIndicatorProps {
+  status: SaveStatus;
+}
+
+export function SaveIndicator({ status }: SaveIndicatorProps) {
+  if (status === "idle") return null;
+
+  const base = "inline-block h-1.5 w-1.5 rounded-full align-middle";
+
+  if (status === "saving") {
+    return (
+      <span
+        aria-label="Saving"
+        className={`${base} save-indicator-pulse`}
+        style={{ background: "var(--ink-ghost, #C9C0B0)" }}
+      />
+    );
+  }
+
+  if (status === "saved") {
+    return (
+      <span
+        aria-label="Saved"
+        className={base}
+        style={{ background: "var(--terracotta, #B8472D)", opacity: 0.5 }}
+      />
+    );
+  }
+
+  // error
+  return (
+    <span
+      aria-label="Save failed — your edits are still in the editor"
+      title="Save failed — your edits are still in the editor"
+      className={base}
+      style={{ background: "#8C341E", opacity: 0.85 }}
+    />
+  );
+}

--- a/homebase/src/hooks/useAutosave.ts
+++ b/homebase/src/hooks/useAutosave.ts
@@ -1,0 +1,51 @@
+// useAutosave — debounce-and-flush hook for one accordion row.
+//
+// Subscribes to the strategy store's content + dirty flag for `horizon`.
+// When dirty content changes, schedules a flush() after `debounceMs`. On
+// successful save, the store transitions saveStatus → "saved"; this hook
+// then schedules a settle to reset → "idle" after `settleMs` so the
+// indicator dot fades.
+//
+// Returns a `flushNow()` callback that forces an immediate save — meant
+// to be called from the editor's onBlur so unsaved drafts are persisted
+// when the user navigates away from the row.
+
+import { useEffect } from "react";
+import type { Horizon } from "../lib/period-key";
+import { useStrategyStore } from "../store/strategy";
+
+interface AutosaveResult {
+  flushNow: () => Promise<void>;
+}
+
+export function useAutosave(horizon: Horizon, debounceMs = 500, settleMs = 2000): AutosaveResult {
+  const content = useStrategyStore((s) => s.rows[horizon].content);
+  const dirty = useStrategyStore((s) => s.rows[horizon].dirty);
+  const saveStatus = useStrategyStore((s) => s.rows[horizon].saveStatus);
+  const flush = useStrategyStore((s) => s.flush);
+  const resetSaveStatus = useStrategyStore((s) => s.resetSaveStatus);
+
+  // Debounced save: schedule a flush whenever dirty content changes.
+  // The hook deliberately ignores rejections — the store sets
+  // saveStatus="error" on failure, which is the user-visible signal.
+  useEffect(() => {
+    if (!dirty) return;
+    const id = setTimeout(() => {
+      flush(horizon).catch(() => {
+        // Error already reflected in saveStatus; nothing more to do here.
+      });
+    }, debounceMs);
+    return () => clearTimeout(id);
+  }, [content, dirty, horizon, flush, debounceMs]);
+
+  // Settle: after a successful save, fade the indicator back to idle.
+  useEffect(() => {
+    if (saveStatus !== "saved") return;
+    const id = setTimeout(() => resetSaveStatus(horizon), settleMs);
+    return () => clearTimeout(id);
+  }, [saveStatus, horizon, resetSaveStatus, settleMs]);
+
+  return {
+    flushNow: () => flush(horizon),
+  };
+}

--- a/homebase/src/index.css
+++ b/homebase/src/index.css
@@ -79,3 +79,19 @@ body {
 .ritual-editor .cm-editor {
   background: transparent;
 }
+
+/* Strategic-layer save indicator — a 6px dot lower-right of each editor
+ * that pulses softly while saving and settles to a steady terracotta when
+ * saved. Used by SaveIndicator. */
+@keyframes save-indicator-pulse {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+.save-indicator-pulse {
+  animation: save-indicator-pulse 1.6s ease-in-out infinite;
+}

--- a/homebase/src/store/strategy.test.ts
+++ b/homebase/src/store/strategy.test.ts
@@ -118,6 +118,23 @@ describe("StrategyStore", () => {
     expect(store.getState().rows["life-values"].saveStatus).toBe("idle");
   });
 
+  it("flush surfaces failures via saveStatus='error' and keeps dirty=true for retry", async () => {
+    // Build a fake fs whose write rejects, simulating a disk/permission failure.
+    const failingFs = createFakeStrategyFs();
+    failingFs.write = async () => {
+      throw new Error("disk full");
+    };
+
+    const store = createStrategyStore(failingFs);
+    await store.getState().expandRow("life-values");
+    store.getState().setContent("life-values", "courage");
+    await expect(store.getState().flush("life-values")).rejects.toThrow("disk full");
+
+    const row = store.getState().rows["life-values"];
+    expect(row.saveStatus).toBe("error");
+    expect(row.dirty).toBe(true); // content not lost; next edit/blur will retry
+  });
+
   it("resetSaveStatus brings saveStatus back to idle (consumer-driven settle)", async () => {
     const fs = createFakeStrategyFs();
     const store = createStrategyStore(fs);

--- a/homebase/src/store/strategy.ts
+++ b/homebase/src/store/strategy.ts
@@ -13,7 +13,7 @@ import { CarryOverResolver, type CarryOver } from "../lib/carry-over-resolver";
 import { PeriodKey, type Horizon } from "../lib/period-key";
 import { StrategyFs, type StrategyFsApi } from "../lib/strategy-fs";
 
-export type SaveStatus = "idle" | "saving" | "saved";
+export type SaveStatus = "idle" | "saving" | "saved" | "error";
 
 export interface RowState {
   expanded: boolean;
@@ -185,8 +185,12 @@ export function createStrategyStore(fs: StrategyFsApi): UseBoundStore<StoreApi<S
           },
         }));
       } catch (err) {
+        // Surface the failure via saveStatus="error" — the SaveIndicator
+        // will render an error pip until the next successful save (or until
+        // the user retries by editing again, which moves us to "saving").
+        // dirty stays true so the next edit/blur retries.
         set((s) => ({
-          rows: { ...s.rows, [horizon]: { ...s.rows[horizon], saveStatus: "idle" } },
+          rows: { ...s.rows, [horizon]: { ...s.rows[horizon], saveStatus: "error" } },
         }));
         throw err;
       }


### PR DESCRIPTION
Implements **#7**. `useAutosave` hook (debounce 500ms + 2s settle), `SaveIndicator` component (idle/saving/saved/error), and a `save-indicator-pulse` keyframe. SaveStatus extended with 'error' so the indicator stays visible after failed writes (dirty stays true for retry). 64 tests pass.