### PR TITLE
feat(strategy): HorizonRow component with three variants (closes #8)

### DIFF
--- a/homebase/src/components/CarryOverBanner.tsx
+++ b/homebase/src/components/CarryOverBanner.tsx
@@ -1,0 +1,34 @@
+// CarryOverBanner — minimal pass-through implementation. The polished
+// "marginalia" version (※ reference mark, dotted hairline, terracotta
+// clear link, italic Newsreader register) lands in #10. This file
+// exists so HorizonRow can render the carry-over flow end-to-end now;
+// expect #10 to replace the body wholesale, keeping the same props.
+
+import { PeriodKey, type Horizon } from "../lib/period-key";
+
+interface Props {
+  horizon: Exclude<Horizon, "life-values" | "life-goals">;
+  sourcePeriod: string;
+  onClear: () => void;
+}
+
+export function CarryOverBanner({ horizon, sourcePeriod, onClear }: Props) {
+  const sourceLabel = PeriodKey.format(horizon, sourcePeriod);
+  return (
+    <div
+      className="mb-3 pb-2 pt-2 font-serif text-[14px] italic"
+      style={{ color: "var(--ink-muted, #7A7268)" }}
+    >
+      Carried from <strong className="not-italic">{sourceLabel}</strong> — review and edit, or{" "}
+      <button
+        type="button"
+        onClick={onClear}
+        className="cursor-pointer border-b border-dotted bg-transparent p-0 not-italic"
+        style={{ color: "var(--terracotta, #B8472D)", borderColor: "var(--terracotta, #B8472D)" }}
+      >
+        clear
+      </button>
+      .
+    </div>
+  );
+}

--- a/homebase/src/components/HorizonRow.test.tsx
+++ b/homebase/src/components/HorizonRow.test.tsx
@@ -1,0 +1,57 @@
+// HorizonRow tests — render-only smoke. Interactions (click → expand,
+// click checkbox → toggle) need a real browser; we limit ourselves to
+// what jsdom can verify reliably.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { HorizonRow } from "./HorizonRow";
+
+describe("HorizonRow", () => {
+  it("Day row shows 'Open morning ritual' and a → arrow", () => {
+    render(<HorizonRow horizon="day" />);
+    expect(screen.getByText("Day")).toBeInTheDocument();
+    expect(screen.getByText("Open morning ritual")).toBeInTheDocument();
+    expect(screen.getByText("→")).toBeInTheDocument();
+  });
+
+  it("Day row click triggers onDayClick", () => {
+    const onDayClick = vi.fn();
+    render(<HorizonRow horizon="day" onDayClick={onDayClick} />);
+    screen.getByRole("button").click();
+    expect(onDayClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("persistent row (life-values) shows 'Persistent' meta and + glyph", () => {
+    render(<HorizonRow horizon="life-values" />);
+    expect(screen.getByText("Life values")).toBeInTheDocument();
+    expect(screen.getByText("Persistent")).toBeInTheDocument();
+    expect(screen.getByText("+")).toBeInTheDocument();
+  });
+
+  it("persistent row (life-goals) shows 'Persistent' meta", () => {
+    render(<HorizonRow horizon="life-goals" />);
+    expect(screen.getByText("Life goals")).toBeInTheDocument();
+    expect(screen.getByText("Persistent")).toBeInTheDocument();
+  });
+
+  it("year row shows the current ISO year as metadata", () => {
+    render(<HorizonRow horizon="year" />);
+    expect(screen.getByText("Year")).toBeInTheDocument();
+    // Don't lock to a specific year — test runs forever.
+    const meta = screen.getAllByText(/^\d{4}$/);
+    expect(meta.length).toBeGreaterThan(0);
+  });
+
+  it("month row shows 'Month YYYY' as metadata", () => {
+    render(<HorizonRow horizon="month" />);
+    expect(screen.getByText("Month")).toBeInTheDocument();
+    // Match e.g. "April 2026"
+    expect(screen.getByText(/^[A-Z][a-z]+ \d{4}$/)).toBeInTheDocument();
+  });
+
+  it("week row shows 'Week N, YYYY' as metadata", () => {
+    render(<HorizonRow horizon="week" />);
+    expect(screen.getByText("Week")).toBeInTheDocument();
+    expect(screen.getByText(/^Week \d{1,2}, \d{4}$/)).toBeInTheDocument();
+  });
+});

--- a/homebase/src/components/HorizonRow.tsx
+++ b/homebase/src/components/HorizonRow.tsx
@@ -1,0 +1,217 @@
+// HorizonRow — one row of the strategic accordion.
+//
+// Three variants based on `horizon`:
+//
+//   - Persistent (life-values, life-goals): header → expanded body with
+//     MarkdownEditor + SaveIndicator. No banner, no portal.
+//
+//   - Time-bound (year, month, week): header → expanded body with the
+//     carry-over banner (when state.carryOver is non-null) above
+//     MarkdownEditor + SaveIndicator.
+//
+//   - Day: header is a portal — clicking it triggers `onDayClick`
+//     (route navigation lands in #11). No expand body ever.
+//
+// Layout matches .llm/design-strategic-layer/mock.html .row-head:
+//
+//   [ i. ]   Italic Newsreader title       Metadata col   [ + / → ]
+//
+// CSS variables (--page, --ink, --terracotta, --hairline, etc.) come
+// from the StrategyAccordion route container in #9; tasteful fallbacks
+// live in this component for isolated rendering / tests.
+
+import { useEffect } from "react";
+import { CarryOverBanner } from "./CarryOverBanner";
+import { MarkdownEditor } from "./MarkdownEditor";
+import { SaveIndicator } from "./SaveIndicator";
+import { useAutosave } from "../hooks/useAutosave";
+import { PeriodKey, type Horizon } from "../lib/period-key";
+import { useStrategyStore } from "../store/strategy";
+
+const ROMAN: Record<Horizon | "day", string> = {
+  "life-values": "i.",
+  "life-goals": "ii.",
+  year: "iii.",
+  month: "iv.",
+  week: "v.",
+  day: "vi.",
+};
+
+const TITLE: Record<Horizon | "day", string> = {
+  "life-values": "Life values",
+  "life-goals": "Life goals",
+  year: "Year",
+  month: "Month",
+  week: "Week",
+  day: "Day",
+};
+
+const PLACEHOLDER: Record<Horizon, string> = {
+  "life-values": "How do you want to live? Begin anywhere.",
+  "life-goals": "What are you aiming at? List the things that pull you forward.",
+  year: "What is this year for?",
+  month: "What is this month about?",
+  week: "What is this week for?",
+};
+
+/** Metadata text shown in the header's right column. */
+function metaFor(horizon: Horizon | "day"): string {
+  if (horizon === "day") return "Open morning ritual";
+  if (horizon === "life-values" || horizon === "life-goals") return "Persistent";
+  const key = PeriodKey.current(horizon);
+  if (!key) return "";
+  return PeriodKey.format(horizon, key);
+}
+
+interface HorizonRowProps {
+  horizon: Horizon | "day";
+  onDayClick?: () => void;
+}
+
+export function HorizonRow(props: HorizonRowProps) {
+  if (props.horizon === "day") {
+    return <DayRow onDayClick={props.onDayClick} />;
+  }
+  return <StrategyRow horizon={props.horizon} />;
+}
+
+// -- Day row (portal) ----------------------------------------------------
+
+function DayRow({ onDayClick }: { onDayClick?: () => void }) {
+  return (
+    <div className="row-day border-b" style={{ borderColor: "var(--hairline, #E5DFD3)" }}>
+      <button
+        type="button"
+        onClick={onDayClick}
+        className="grid w-full cursor-pointer items-baseline px-0 py-[22px] text-left transition-colors hover:bg-[rgba(184,71,45,0.08)]"
+        style={{
+          gridTemplateColumns: "28px 1fr auto 24px",
+        }}
+      >
+        <span
+          className="self-center font-sans text-[10px] tracking-[0.1em]"
+          style={{ color: "var(--ink-ghost, #C9C0B0)" }}
+        >
+          {ROMAN.day}
+        </span>
+        <h2
+          className="row-day-title font-serif text-[28px] font-light italic leading-[1.1] tracking-tight"
+          style={{ color: "var(--ink, #1A1614)" }}
+        >
+          {TITLE.day}
+        </h2>
+        <span
+          className="row-day-meta whitespace-nowrap self-center px-4 font-sans text-[10px] uppercase tracking-[0.12em]"
+          style={{ color: "var(--terracotta, #B8472D)", opacity: 0.7 }}
+        >
+          {metaFor("day")}
+        </span>
+        <span
+          className="row-day-arrow self-center text-center font-serif text-[18px] leading-none transition-transform"
+          style={{ color: "var(--terracotta, #B8472D)" }}
+        >
+          →
+        </span>
+      </button>
+    </div>
+  );
+}
+
+// -- Strategy row (persistent + time-bound) -----------------------------
+
+function StrategyRow({ horizon }: { horizon: Exclude<Horizon | "day", "day"> }) {
+  const row = useStrategyStore((s) => s.rows[horizon]);
+  const expandRow = useStrategyStore((s) => s.expandRow);
+  const collapseRow = useStrategyStore((s) => s.collapseRow);
+  const setContent = useStrategyStore((s) => s.setContent);
+  const clearCarryOver = useStrategyStore((s) => s.clearCarryOver);
+
+  // Wire autosave for this row. The hook subscribes to dirty/content and
+  // schedules saves; the indicator below reads saveStatus.
+  const { flushNow } = useAutosave(horizon);
+
+  // Flush any pending save when the component unmounts (route change /
+  // accordion teardown), guaranteeing no in-flight buffer is lost.
+  useEffect(() => {
+    return () => {
+      if (row.dirty) {
+        flushNow().catch(() => {});
+      }
+    };
+    // Read row.dirty/flushNow at unmount time. We deliberately don't
+    // re-subscribe — only the unmount cleanup matters here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onToggle = () => {
+    if (row.expanded) {
+      collapseRow(horizon);
+    } else {
+      expandRow(horizon).catch(() => {});
+    }
+  };
+
+  return (
+    <div className="border-b" style={{ borderColor: "var(--hairline, #E5DFD3)" }}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="grid w-full cursor-pointer items-baseline px-0 py-[22px] text-left transition-colors hover:bg-[rgba(184,71,45,0.08)]"
+        style={{
+          gridTemplateColumns: "28px 1fr auto 24px",
+        }}
+      >
+        <span
+          className="self-center font-sans text-[10px] tracking-[0.1em]"
+          style={{ color: "var(--ink-ghost, #C9C0B0)" }}
+        >
+          {ROMAN[horizon]}
+        </span>
+        <h2
+          className="font-serif text-[28px] font-light italic leading-[1.1] tracking-tight"
+          style={{ color: "var(--ink, #1A1614)" }}
+        >
+          {TITLE[horizon]}
+        </h2>
+        <span
+          className="whitespace-nowrap self-center px-4 font-sans text-[10px] uppercase tracking-[0.12em]"
+          style={{ color: "var(--ink-faint, #A39A8A)" }}
+        >
+          {metaFor(horizon)}
+        </span>
+        <span
+          aria-hidden="true"
+          className="self-center text-center font-serif text-[22px] leading-none transition-transform duration-[250ms]"
+          style={{
+            color: "var(--ink-ghost, #C9C0B0)",
+            transform: row.expanded ? "rotate(45deg)" : "none",
+          }}
+        >
+          +
+        </span>
+      </button>
+
+      {row.expanded && (
+        <div className="pb-9 pl-7 pt-1">
+          {row.carryOver && (
+            <CarryOverBanner
+              horizon={horizon}
+              sourcePeriod={row.carryOver.sourcePeriod}
+              onClear={() => clearCarryOver(horizon)}
+            />
+          )}
+          <div className="relative max-w-[62ch]">
+            <MarkdownEditor
+              value={row.content}
+              onChange={(v) => setContent(horizon, v)}
+              placeholder={PLACEHOLDER[horizon]}
+            />
+            <span className="absolute -right-2 bottom-0">
+              <SaveIndicator status={row.saveStatus} />
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Implements **#8**. Persistent / time-bound / day-portal variants. Wires autosave + flush-on-unmount. Includes a minimal CarryOverBanner stub which #10 will replace with the polished marginalia design (same props). 71 tests pass.