### PR TITLE
feat(strategy): /strategy route + masthead + Lapham CSS scope (closes #9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
       # explicitly so TypeScript errors gate the merge. Drop this step once
       # vp check folds typecheck in.
       - name: Typecheck
-        run: pnpm typecheck
+        # vp 0.0.0 has no `vp typecheck` builtin; `vp run typecheck`
+        # forwards to the package.json script (tsc --noEmit).
+        run: vp run typecheck
 
       - name: Run tests
         run: vp test run --passWithNoTests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,14 @@ jobs:
       - name: Install dependencies
         run: vp install
 
-      - name: Lint and typecheck
+      - name: Format and lint
         run: vp check
+
+      # vp 0.0.0's `vp check` doesn't yet run tsc; running typecheck
+      # explicitly so TypeScript errors gate the merge. Drop this step once
+      # vp check folds typecheck in.
+      - name: Typecheck
+        run: pnpm typecheck
 
       - name: Run tests
         run: vp test run --passWithNoTests

--- a/homebase/src/components/CarryOverBanner.tsx
+++ b/homebase/src/components/CarryOverBanner.tsx
@@ -6,8 +6,14 @@
 
 import { PeriodKey, type Horizon } from "../lib/period-key";
 
+/**
+ * Props accept any Horizon for ergonomic JSX in HorizonRow. In practice
+ * the banner only renders when state.carryOver is non-null, which only
+ * happens for time-bound horizons; PeriodKey.format will throw if the
+ * caller violates that invariant.
+ */
 interface Props {
-  horizon: Exclude<Horizon, "life-values" | "life-goals">;
+  horizon: Horizon;
   sourcePeriod: string;
   onClear: () => void;
 }

--- a/homebase/src/index.css
+++ b/homebase/src/index.css
@@ -80,6 +80,33 @@ body {
   background: transparent;
 }
 
+/* Strategic layer (front-door accordion) — Lapham editorial palette.
+ *
+ * Scoped to .strategy-scope so the warm-cream/terracotta vars only apply
+ * inside the strategic accordion route (StrategyAccordion). The morning
+ * ritual keeps its existing white/gray palette unchanged — strategic and
+ * morning are deliberately *different rooms in the same magazine* per
+ * the design rationale at .llm/design-strategic-layer/rationale.md.
+ *
+ * Note these are scoped CSS variables (not Tailwind theme tokens) — they
+ * piggyback on `style={{ background: 'var(--terracotta)' }}` patterns in
+ * HorizonRow, MarkdownEditor, etc. Components carry inline fallbacks so
+ * isolated renders (tests) still look intentional. */
+.strategy-scope {
+  --page: #faf7f0;
+  --ref: #f2ecdc;
+  --ink: #1a1614;
+  --ink-muted: #7a7268;
+  --ink-faint: #a39a8a;
+  --ink-ghost: #c9c0b0;
+  --hairline: #e5dfd3;
+  --hairline-2: #d9d2c0;
+  --terracotta: #b8472d;
+  --terracotta-soft: rgba(184, 71, 45, 0.08);
+  background-color: var(--page);
+  color: var(--ink);
+}
+
 /* Strategic-layer save indicator — a 6px dot lower-right of each editor
  * that pulses softly while saving and settles to a steady terracotta when
  * saved. Used by SaveIndicator. */

--- a/homebase/src/lib/fsa.d.ts
+++ b/homebase/src/lib/fsa.d.ts
@@ -18,3 +18,9 @@ interface Window {
     startIn?: FileSystemHandle | string;
   }): Promise<FileSystemDirectoryHandle>;
 }
+
+interface FileSystemDirectoryHandle {
+  entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+  values(): AsyncIterableIterator<FileSystemHandle>;
+  keys(): AsyncIterableIterator<string>;
+}

--- a/homebase/src/lib/period-key.ts
+++ b/homebase/src/lib/period-key.ts
@@ -141,6 +141,10 @@ export const PeriodKey = {
         if (!m) throw new Error(`invalid week key: ${key}`);
         return `Week ${Number(m[2])}, ${m[1]}`;
       }
+      default:
+        // Unreachable — isTimeBound() narrowed `horizon` above. Throw
+        // satisfies the type checker without lying about behavior.
+        throw new Error(`unreachable: format(${horizon as string})`);
     }
   },
 };

--- a/homebase/src/routes/strategy.tsx
+++ b/homebase/src/routes/strategy.tsx
@@ -1,0 +1,97 @@
+// /strategy — the strategic accordion, the new front door for Homebase
+// (per the active-plan's "Solution" framing). For this issue (#9) it lives
+// at /strategy alongside /morning. #13 swaps it to "/" and the morning
+// route stays accessible via the Day-row portal.
+//
+// Three things compose here: the Lapham CSS token scope, the masthead
+// (deck + title + dateline + terracotta rule), and the six HorizonRows
+// in fixed order. Day's onDayClick is wired in #11.
+
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { HorizonRow } from "../components/HorizonRow";
+import { StrategyPermissionGate } from "../components/StrategyPermissionGate";
+import { PeriodKey } from "../lib/period-key";
+
+export const Route = createFileRoute("/strategy")({
+  component: StrategyAccordion,
+});
+
+function StrategyAccordion() {
+  const navigate = useNavigate();
+  return (
+    <StrategyPermissionGate>
+      <div className="strategy-scope min-h-screen">
+        <div className="mx-auto max-w-[720px] px-10 pb-16">
+          <Masthead />
+          <div className="stack mt-6 border-t" style={{ borderColor: "var(--hairline)" }}>
+            <HorizonRow horizon="life-values" />
+            <HorizonRow horizon="life-goals" />
+            <HorizonRow horizon="year" />
+            <HorizonRow horizon="month" />
+            <HorizonRow horizon="week" />
+            <HorizonRow horizon="day" onDayClick={() => navigate({ to: "/morning" })} />
+          </div>
+        </div>
+      </div>
+    </StrategyPermissionGate>
+  );
+}
+
+function Masthead() {
+  const today = new Date();
+  const dateline = formatDateline(today);
+  return (
+    <header className="pt-9 text-center">
+      <div
+        className="mb-2 font-sans text-[10px] uppercase"
+        style={{ color: "var(--ink-faint)", letterSpacing: "0.18em" }}
+      >
+        a strategic life guide
+      </div>
+      <h1
+        className="font-serif text-[38px] font-light italic leading-[1.1] tracking-tight"
+        style={{ color: "var(--ink)" }}
+      >
+        Homebase
+      </h1>
+      <div
+        className="mt-2 font-sans text-[11px] uppercase"
+        style={{ color: "var(--ink-faint)", letterSpacing: "0.1em" }}
+      >
+        {dateline}
+      </div>
+      <div
+        className="mx-auto mt-4 h-px w-9"
+        style={{ background: "var(--terracotta)" }}
+        aria-hidden="true"
+      />
+    </header>
+  );
+}
+
+const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+function formatDateline(d: Date): string {
+  const day = DAYS[d.getDay()];
+  const month = MONTHS[d.getMonth()];
+  const date = d.getDate();
+  const year = d.getFullYear();
+  const weekKey = PeriodKey.current("week", d);
+  // Extract just the "Wnn" portion from "YYYY-Wnn".
+  const week = weekKey ? weekKey.split("-W")[1].replace(/^0/, "") : "";
+  return `${day} · ${month} ${date}, ${year} · Week ${week}`;
+}

--- a/homebase/src/slots/orient/index.tsx
+++ b/homebase/src/slots/orient/index.tsx
@@ -63,7 +63,11 @@ export function OrientSlot({ initialDraft, onDraft }: SlotProps) {
         <p className="mb-2 font-serif text-[15px] italic leading-relaxed text-[#9CA3AF]">
           {QUESTION}
         </p>
-        <RitualEditor initialContent={initialDraft} onChange={onDraft} placeholder="Write here…" />
+        <RitualEditor
+          initialContent={initialDraft}
+          onChange={onDraft}
+          placeholderText="Write here…"
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
Implements **#9**. Three commits:

1. **fix(types)**: clears 4 pre-existing TypeScript errors that had accumulated because vp 0.0.0's `vp check` doesn't run tsc — they slipped past prior CI runs.
2. **chore(ci)**: adds an explicit `pnpm typecheck` step to the CI workflow so TS errors gate merges going forward.
3. **feat(strategy)**: `/strategy` route with masthead (deck + italic title + tracked dateline + terracotta rule) and six HorizonRows. Lapham palette scoped to `.strategy-scope` so the morning ritual is unaffected.

After this lands, `/strategy` exists alongside `/morning`. **#13** will swap `/strategy` to `/` so the accordion becomes the front door.

71 tests pass, 0 lint/format/type errors.