### PR TITLE
feat(strategy): CarryOverBanner marginalia design (closes #10)

### DIFF
--- a/homebase/src/components/CarryOverBanner.test.tsx
+++ b/homebase/src/components/CarryOverBanner.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { CarryOverBanner } from "./CarryOverBanner";
+
+describe("CarryOverBanner", () => {
+  it("renders the formatted source period and the clear link", () => {
+    render(<CarryOverBanner horizon="month" sourcePeriod="2026-03" onClear={() => {}} />);
+    expect(screen.getByText(/Carried from/)).toBeInTheDocument();
+    expect(screen.getByText("March 2026")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "clear" })).toBeInTheDocument();
+  });
+
+  it("formats year horizon as the bare year", () => {
+    render(<CarryOverBanner horizon="year" sourcePeriod="2025" onClear={() => {}} />);
+    expect(screen.getByText("2025")).toBeInTheDocument();
+  });
+
+  it("formats week horizon as 'Week N, YYYY'", () => {
+    render(<CarryOverBanner horizon="week" sourcePeriod="2026-W17" onClear={() => {}} />);
+    expect(screen.getByText("Week 17, 2026")).toBeInTheDocument();
+  });
+
+  it("calls onClear when the clear link is clicked", () => {
+    const onClear = vi.fn();
+    render(<CarryOverBanner horizon="month" sourcePeriod="2026-03" onClear={onClear} />);
+    screen.getByRole("button", { name: "clear" }).click();
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the asterism glyph (※) as the marginalia mark", () => {
+    const { container } = render(
+      <CarryOverBanner horizon="month" sourcePeriod="2026-03" onClear={() => {}} />,
+    );
+    expect(container.textContent).toContain("※");
+  });
+});

--- a/homebase/src/components/CarryOverBanner.tsx
+++ b/homebase/src/components/CarryOverBanner.tsx
@@ -1,17 +1,25 @@
-// CarryOverBanner — minimal pass-through implementation. The polished
-// "marginalia" version (※ reference mark, dotted hairline, terracotta
-// clear link, italic Newsreader register) lands in #10. This file
-// exists so HorizonRow can render the carry-over flow end-to-end now;
-// expect #10 to replace the body wholesale, keeping the same props.
+// CarryOverBanner — magazine marginalia for "this content was carried
+// from a prior period." The closest spiritual precedent for this UX is
+// Sunsama's per-item Extend button on weekly objectives, but theirs is
+// per-item and ours is per-document — so we invented our own register:
+//
+//   ※   *Carried from <strong>April 2026</strong> — review and edit, or
+//       <span class="clear">clear</span>.*
+//   ──── (dotted hairline)
+//
+// The reference mark (※, asterism — the glyph Lapham uses for footnote
+// callouts) sits in the left margin in terracotta. Body is italic
+// Newsreader 14px in --ink-muted; the "clear" link is dotted-underlined
+// terracotta, darkening to #8C341E on hover. Dotted hairline below
+// marks the end of the marginalia register so the editor below it
+// reads as content, not continuation.
+//
+// Behavior: parent (HorizonRow) only mounts this when state.carryOver
+// is non-null. First content edit dismisses it via setContent → store
+// clears carryOver → parent unmounts the banner.
 
 import { PeriodKey, type Horizon } from "../lib/period-key";
 
-/**
- * Props accept any Horizon for ergonomic JSX in HorizonRow. In practice
- * the banner only renders when state.carryOver is non-null, which only
- * happens for time-bound horizons; PeriodKey.format will throw if the
- * caller violates that invariant.
- */
 interface Props {
   horizon: Horizon;
   sourcePeriod: string;
@@ -22,19 +30,36 @@ export function CarryOverBanner({ horizon, sourcePeriod, onClear }: Props) {
   const sourceLabel = PeriodKey.format(horizon, sourcePeriod);
   return (
     <div
-      className="mb-3 pb-2 pt-2 font-serif text-[14px] italic"
-      style={{ color: "var(--ink-muted, #7A7268)" }}
+      className="carry-over-banner relative mb-3 max-w-[62ch] pb-3"
+      style={{ borderBottom: "1px dotted var(--hairline-2, #D9D2C0)" }}
     >
-      Carried from <strong className="not-italic">{sourceLabel}</strong> — review and edit, or{" "}
-      <button
-        type="button"
-        onClick={onClear}
-        className="cursor-pointer border-b border-dotted bg-transparent p-0 not-italic"
-        style={{ color: "var(--terracotta, #B8472D)", borderColor: "var(--terracotta, #B8472D)" }}
+      <span
+        aria-hidden="true"
+        className="absolute left-[-22px] top-[2px] font-sans text-[12px]"
+        style={{ color: "var(--terracotta, #B8472D)" }}
       >
-        clear
-      </button>
-      .
+        ※
+      </span>
+      <p
+        className="font-serif text-[14px] italic leading-[1.55]"
+        style={{ color: "var(--ink-muted, #7A7268)" }}
+      >
+        Carried from <strong className="not-italic">{sourceLabel}</strong> — review and edit, or{" "}
+        <button
+          type="button"
+          onClick={onClear}
+          className="carry-over-clear cursor-pointer border-b border-dotted bg-transparent p-0 align-baseline not-italic"
+          style={{
+            color: "var(--terracotta, #B8472D)",
+            borderColor: "var(--terracotta, #B8472D)",
+            font: "inherit",
+            fontStyle: "normal",
+          }}
+        >
+          clear
+        </button>
+        .
+      </p>
     </div>
   );
 }

--- a/homebase/src/index.css
+++ b/homebase/src/index.css
@@ -122,3 +122,14 @@ body {
 .save-indicator-pulse {
   animation: save-indicator-pulse 1.6s ease-in-out infinite;
 }
+
+/* Strategic-layer carry-over banner (Lapham marginalia register).
+ *
+ * Hover state on the "clear" link darkens the terracotta. Component-level
+ * inline styles handle layout + idle color; this ruleset only owns the
+ * hover state since Tailwind v4 doesn't yet have a clean way to express
+ * hover on a CSS variable. */
+.carry-over-clear:hover {
+  color: #8c341e !important;
+  border-color: #8c341e !important;
+}

--- a/homebase/src/routeTree.gen.ts
+++ b/homebase/src/routeTree.gen.ts
@@ -9,12 +9,18 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as StrategyRouteImport } from './routes/strategy'
 import { Route as NotesRouteImport } from './routes/notes'
 import { Route as MorningRouteImport } from './routes/morning'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WorkspaceNameRouteImport } from './routes/workspace.$name'
 import { Route as SlotNameRouteImport } from './routes/slot.$name'
 
+const StrategyRoute = StrategyRouteImport.update({
+  id: '/strategy',
+  path: '/strategy',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const NotesRoute = NotesRouteImport.update({
   id: '/notes',
   path: '/notes',
@@ -45,6 +51,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/morning': typeof MorningRoute
   '/notes': typeof NotesRoute
+  '/strategy': typeof StrategyRoute
   '/slot/$name': typeof SlotNameRoute
   '/workspace/$name': typeof WorkspaceNameRoute
 }
@@ -52,6 +59,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/morning': typeof MorningRoute
   '/notes': typeof NotesRoute
+  '/strategy': typeof StrategyRoute
   '/slot/$name': typeof SlotNameRoute
   '/workspace/$name': typeof WorkspaceNameRoute
 }
@@ -60,19 +68,33 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/morning': typeof MorningRoute
   '/notes': typeof NotesRoute
+  '/strategy': typeof StrategyRoute
   '/slot/$name': typeof SlotNameRoute
   '/workspace/$name': typeof WorkspaceNameRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/morning' | '/notes' | '/slot/$name' | '/workspace/$name'
+  fullPaths:
+    | '/'
+    | '/morning'
+    | '/notes'
+    | '/strategy'
+    | '/slot/$name'
+    | '/workspace/$name'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/morning' | '/notes' | '/slot/$name' | '/workspace/$name'
+  to:
+    | '/'
+    | '/morning'
+    | '/notes'
+    | '/strategy'
+    | '/slot/$name'
+    | '/workspace/$name'
   id:
     | '__root__'
     | '/'
     | '/morning'
     | '/notes'
+    | '/strategy'
     | '/slot/$name'
     | '/workspace/$name'
   fileRoutesById: FileRoutesById
@@ -81,12 +103,20 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   MorningRoute: typeof MorningRoute
   NotesRoute: typeof NotesRoute
+  StrategyRoute: typeof StrategyRoute
   SlotNameRoute: typeof SlotNameRoute
   WorkspaceNameRoute: typeof WorkspaceNameRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/strategy': {
+      id: '/strategy'
+      path: '/strategy'
+      fullPath: '/strategy'
+      preLoaderRoute: typeof StrategyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/notes': {
       id: '/notes'
       path: '/notes'
@@ -129,6 +159,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   MorningRoute: MorningRoute,
   NotesRoute: NotesRoute,
+  StrategyRoute: StrategyRoute,
   SlotNameRoute: SlotNameRoute,
   WorkspaceNameRoute: WorkspaceNameRoute,
 }


### PR DESCRIPTION
Implements **#10**. Replaces the #8 stub with the polished marginalia design from the mock — ※ reference mark, italic body, dotted hairline, terracotta clear link. 5 new tests. 76 tests pass total.