### PR TITLE
feat(strategy): empty-state invitation pattern (closes #12)

### DIFF
--- a/homebase/src/components/HorizonInvitation.test.tsx
+++ b/homebase/src/components/HorizonInvitation.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { HorizonInvitation } from "./HorizonInvitation";
+
+describe("HorizonInvitation", () => {
+  it("renders the life-values invitation", () => {
+    render(<HorizonInvitation horizon="life-values" />);
+    expect(screen.getByText(/How do you want to live/)).toBeInTheDocument();
+    expect(screen.getByText(/Begin anywhere/)).toBeInTheDocument();
+  });
+
+  it("renders the life-goals invitation", () => {
+    render(<HorizonInvitation horizon="life-goals" />);
+    expect(screen.getByText(/What are you aiming at/)).toBeInTheDocument();
+    expect(screen.getByText(/pull you forward/)).toBeInTheDocument();
+  });
+
+  it("renders 'No previous year to carry from' for year horizon", () => {
+    render(<HorizonInvitation horizon="year" />);
+    expect(screen.getByText(/No previous year to carry from/)).toBeInTheDocument();
+  });
+
+  it("renders 'No previous month to carry from' for month horizon", () => {
+    render(<HorizonInvitation horizon="month" />);
+    expect(screen.getByText(/No previous month to carry from/)).toBeInTheDocument();
+  });
+
+  it("renders 'No previous week to carry from' for week horizon", () => {
+    render(<HorizonInvitation horizon="week" />);
+    expect(screen.getByText(/No previous week to carry from/)).toBeInTheDocument();
+  });
+
+  it("includes the ⌘ ↩ keyboard hint for time-bound horizons", () => {
+    const { container } = render(<HorizonInvitation horizon="month" />);
+    expect(container.textContent).toContain("⌘");
+    expect(container.textContent).toContain("↩");
+    expect(screen.getByText(/Press/)).toBeInTheDocument();
+  });
+});

--- a/homebase/src/components/HorizonInvitation.tsx
+++ b/homebase/src/components/HorizonInvitation.tsx
@@ -1,0 +1,79 @@
+// HorizonInvitation — the empty-state block shown above the editor for a
+// row that has no content yet (and, for time-bound horizons, no carry-over
+// candidate either). The page is a real page, not a form: italic prose
+// in --ink-ghost names the situation, suggests one thing to do, and shows
+// the ⌘↩ keyboard hint. Auto-dismisses on first keystroke since the
+// parent (HorizonRow) only renders this when row.content === "".
+//
+// Wording per plan §F-Polish-empty-states:
+//   - Time-bound (no history at all): "No previous [week] to carry from.
+//                                       Write what this [period] is for —
+//                                       one paragraph or a few bullets —
+//                                       or come back later."
+//   - life-values: "How do you want to live? Begin anywhere."
+//   - life-goals:  "What are you aiming at? List the things that pull
+//                    you forward."
+
+import type { Horizon } from "../lib/period-key";
+
+interface Props {
+  horizon: Horizon;
+}
+
+const PERIOD_NOUN: Record<"year" | "month" | "week", string> = {
+  year: "year",
+  month: "month",
+  week: "week",
+};
+
+export function HorizonInvitation({ horizon }: Props) {
+  if (horizon === "life-values") {
+    return (
+      <Block>
+        <em>How do you want to live?</em> Begin anywhere.
+      </Block>
+    );
+  }
+  if (horizon === "life-goals") {
+    return (
+      <Block>
+        <em>What are you aiming at?</em> List the things that pull you forward.
+      </Block>
+    );
+  }
+  // Time-bound (year, month, week) with no carry-over candidate.
+  const noun = PERIOD_NOUN[horizon];
+  return (
+    <Block>
+      No previous {noun} to carry from. Write what this {noun} is for — one paragraph or a few
+      bullets — or come back later. Press <Key>⌘</Key>
+      <Key>↩</Key> to save.
+    </Block>
+  );
+}
+
+function Block({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="horizon-invitation mb-3 max-w-[62ch] font-serif text-[16px] italic leading-[1.5]"
+      style={{ color: "var(--ink-ghost, #C9C0B0)" }}
+    >
+      {children}
+    </p>
+  );
+}
+
+function Key({ children }: { children: React.ReactNode }) {
+  return (
+    <span
+      className="mx-[3px] inline-block px-[7px] py-[2px] font-sans text-[10px] uppercase tracking-[0.1em] not-italic"
+      style={{
+        color: "var(--ink-faint, #A39A8A)",
+        border: "1px solid var(--hairline-2, #D9D2C0)",
+        borderRadius: "3px",
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/homebase/src/components/HorizonRow.tsx
+++ b/homebase/src/components/HorizonRow.tsx
@@ -22,6 +22,7 @@
 
 import { useEffect } from "react";
 import { CarryOverBanner } from "./CarryOverBanner";
+import { HorizonInvitation } from "./HorizonInvitation";
 import { MarkdownEditor } from "./MarkdownEditor";
 import { SaveIndicator } from "./SaveIndicator";
 import { useAutosave } from "../hooks/useAutosave";
@@ -194,18 +195,21 @@ function StrategyRow({ horizon }: { horizon: Exclude<Horizon | "day", "day"> }) 
 
       {row.expanded && (
         <div className="pb-9 pl-7 pt-1">
-          {row.carryOver && (
+          {row.carryOver ? (
             <CarryOverBanner
               horizon={horizon}
               sourcePeriod={row.carryOver.sourcePeriod}
               onClear={() => clearCarryOver(horizon)}
             />
+          ) : (
+            row.content === "" && <HorizonInvitation horizon={horizon} />
           )}
           <div className="relative max-w-[62ch]">
             <MarkdownEditor
               value={row.content}
               onChange={(v) => setContent(horizon, v)}
               placeholder={PLACEHOLDER[horizon]}
+              onSave={flushNow}
             />
             <span className="absolute -right-2 bottom-0">
               <SaveIndicator status={row.saveStatus} />

--- a/homebase/src/components/MarkdownEditor.tsx
+++ b/homebase/src/components/MarkdownEditor.tsx
@@ -37,6 +37,13 @@ interface MarkdownEditorProps {
   placeholder?: string;
   readonly?: boolean;
   autoFocus?: boolean;
+  /**
+   * Optional explicit-save callback bound to Cmd-Enter / Ctrl-Enter.
+   * Autosave handles persistence within 500ms anyway; this is the keyboard
+   * affordance for users who want immediate feedback (the SaveIndicator
+   * pulses → settles).
+   */
+  onSave?: () => void;
 }
 
 export function MarkdownEditor({
@@ -45,11 +52,14 @@ export function MarkdownEditor({
   placeholder,
   readonly = false,
   autoFocus = false,
+  onSave,
 }: MarkdownEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
+  const onSaveRef = useRef(onSave);
+  onSaveRef.current = onSave;
 
   // Mount + unmount the editor exactly once per component lifecycle.
   // External `value` updates after mount are accepted via the effect below.
@@ -62,8 +72,19 @@ export function MarkdownEditor({
       }
     });
 
+    const saveBinding = keymap.of([
+      {
+        key: "Mod-Enter",
+        run: () => {
+          onSaveRef.current?.();
+          return true;
+        },
+      },
+    ]);
+
     const extensions: Extension[] = [
       history(),
+      saveBinding,
       keymap.of([...defaultKeymap, ...historyKeymap]),
       markdown(),
       syntaxHighlighting(strategyHighlighting),


### PR DESCRIPTION
Implements **#12**. New `HorizonInvitation` component shown above the editor when there's no content + no carry-over. Wires Cmd+Enter as an explicit-save shortcut on `MarkdownEditor` (via new `onSave` prop), so the "Press ⌘↩ to save" hint in the time-bound invitation is real, not aspirational. 82 tests pass.