### PR TITLE
feat(pwa): SPA fallback + Vite base path (closes #30)

### DIFF
--- a/homebase/index.html
+++ b/homebase/index.html
@@ -11,6 +11,27 @@
 
   <body>
     <div id="root"></div>
+    <!--
+      SPA fallback restoration. Pairs with public/404.html. If we got here
+      via the GitHub Pages 404 → root redirect, the original path lives in
+      a "?/" query segment; decode it and rewrite history BEFORE React or
+      TanStack Router boot, so the router sees the correct URL.
+      Reference: https://github.com/rafgraph/spa-github-pages
+    -->
+    <script type="text/javascript">
+      (function (l) {
+        if (l.search[1] === "/") {
+          var decoded = l.search
+            .slice(1)
+            .split("&")
+            .map(function (s) {
+              return s.replace(/~and~/g, "&");
+            })
+            .join("?");
+          window.history.replaceState(null, null, l.pathname.slice(0, -1) + decoded + l.hash);
+        }
+      })(window.location);
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/homebase/public/404.html
+++ b/homebase/public/404.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Homebase</title>
+    <!--
+      SPA fallback for GitHub Pages.
+
+      GitHub Pages serves this file for any path it can't resolve as a
+      static asset, including unknown client-side routes like
+      /horizon/year. The script below encodes the requested path into a
+      query parameter, redirects to the app's index.html, and then
+      index.html's restoration script (in homebase/index.html) decodes
+      the param and rewrites history before TanStack Router boots.
+
+      Reference: https://github.com/rafgraph/spa-github-pages
+
+      Tuning: pathSegmentsToKeep = 1 because the app is deployed at
+      meninoebom.github.io/homebase/ — the leading "/homebase" segment
+      must be preserved through the redirect. Change to 0 if/when the
+      app moves to a custom domain at the root.
+    -->
+    <script type="text/javascript">
+      var pathSegmentsToKeep = 1;
+      var l = window.location;
+      l.replace(
+        l.protocol +
+          "//" +
+          l.hostname +
+          (l.port ? ":" + l.port : "") +
+          l.pathname
+            .split("/")
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join("/") +
+          "/?/" +
+          l.pathname
+            .slice(1)
+            .split("/")
+            .slice(pathSegmentsToKeep)
+            .join("/")
+            .replace(/&/g, "~and~") +
+          (l.search ? "&" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+          l.hash,
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/homebase/src/main.tsx
+++ b/homebase/src/main.tsx
@@ -5,7 +5,13 @@ import { routeTree } from "./routeTree.gen";
 import { SetupGate } from "./components/SetupGate";
 import "./index.css";
 
-const router = createRouter({ routeTree });
+// basepath comes from Vite's base config (/ in dev, /homebase/ in prod
+// build per vite.config.ts). Trailing slash trimmed because TanStack
+// Router expects the basepath without one.
+const router = createRouter({
+  routeTree,
+  basepath: import.meta.env.BASE_URL.replace(/\/$/, "") || undefined,
+});
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/homebase/vite.config.ts
+++ b/homebase/vite.config.ts
@@ -4,8 +4,20 @@ import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import { VitePWA } from "vite-plugin-pwa";
 
+// Path the app is served under in production. The deploy workflow
+// (.github/workflows/deploy.yml) sets BASE_PATH=/homebase/ before
+// running `vp build`, so dev mode keeps "/" (localhost:3000) and
+// production gets the GitHub Pages subpath. Change to "/" in the
+// deploy workflow if/when a custom domain at the root is added.
+//
+// Static-config form (not the `defineConfig(() => ({...}))` function
+// form) because vp's tool-config loader inspects the default export
+// statically; a function would hide the `fmt` field below.
+const BASE_PATH = process.env.BASE_PATH || "/";
+
 // https://viteplus.dev/config
 export default defineConfig({
+  base: BASE_PATH,
   plugins: [
     // Order matters: TanStack Router plugin must run before the React plugin so
     // the generated routeTree.gen.ts exists before React compiles imports.
@@ -29,8 +41,10 @@ export default defineConfig({
         name: "Homebase",
         short_name: "Homebase",
         description: "A strategic life guide.",
-        start_url: "/",
-        scope: "/",
+        // Match the base so the installed PWA opens to the app, not to
+        // meninoebom.github.io's root (which is the user page).
+        start_url: BASE_PATH,
+        scope: BASE_PATH,
         display: "standalone",
         background_color: "#FAF5EB",
         theme_color: "#7A2618",


### PR DESCRIPTION
Implements **#30**. `public/404.html` redirect shim + `index.html` restoration script + Vite `base` from `$BASE_PATH` env var (defaults to `/` for dev) + TanStack Router `basepath` from `import.meta.env.BASE_URL`. Build verification with `BASE_PATH=/homebase/ pnpm build` emits assets at `/homebase/assets/...`. 103 tests pass.