### PR TITLE
fix(strategy): drop duplicate empty-state copy on horizon page

### DIFF
--- a/homebase/src/routes/horizon.$id.tsx
+++ b/homebase/src/routes/horizon.$id.tsx
@@ -42,14 +42,6 @@ const TITLE: Record<Horizon, string> = {
   week: "Week",
 };
 
-const PLACEHOLDER: Record<Horizon, string> = {
-  "life-values": "How do you want to live? Begin anywhere.",
-  "life-goals": "What are you aiming at? List the things that pull you forward.",
-  year: "What is this year for?",
-  month: "What is this month about?",
-  week: "What is this week for?",
-};
-
 function HorizonEditorPage() {
   const { id } = useParams({ from: "/horizon/$id" });
   const navigate = useNavigate();
@@ -121,10 +113,6 @@ function EditorBody({ horizon }: { horizon: Horizon }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // The HorizonInvitation already names the empty state in italic prose;
-  // showing the editor placeholder at the same time renders the same
-  // sentence twice (e.g. "How do you want to live? Begin anywhere." stacked).
-  // Suppress the placeholder while the invitation owns the screen.
   const showInvitation = !row.carryOver && row.loaded && row.content === "";
 
   return (
@@ -166,11 +154,18 @@ function EditorBody({ horizon }: { horizon: Horizon }) {
         showInvitation && <HorizonInvitation horizon={horizon} />
       )}
 
+      {/* No editor placeholder: HorizonInvitation owns the empty state above
+          the editor, and CarryOverBanner provides context post-load. The
+          previous attempt to suppress the placeholder via a `showInvitation`
+          ternary failed because MarkdownEditor's CodeMirror state captures
+          the placeholder on first mount (useEffect with empty deps) — by
+          the time `row.loaded` flipped to true, the placeholder was already
+          baked in and could not be retracted. Dropping it entirely is the
+          cleanest fix. */}
       <div className="relative max-w-[62ch]">
         <MarkdownEditor
           value={row.content}
           onChange={(v) => setContent(horizon, v)}
-          placeholder={showInvitation ? "" : PLACEHOLDER[horizon]}
           onSave={flushNow}
           autoFocus
         />


### PR DESCRIPTION
## Summary

Fixes the visible duplication of *"How do you want to live? Begin anywhere."* on `/horizon/life-values` (and the analogous goal-page). The previous fix shipped in #37 didn't actually take effect at runtime — see context below.

## Why the #37 fix didn't work

The earlier attempt suppressed the editor placeholder via a `showInvitation` ternary:

```tsx
const showInvitation = !row.carryOver && row.loaded && row.content === "";
placeholder={showInvitation ? "" : PLACEHOLDER[horizon]}
```

But `MarkdownEditor` builds its CodeMirror `EditorView` inside a `useEffect(() => {...}, [])` with empty deps. The placeholder is captured into CodeMirror's internal state at first mount and is *not* reactive to subsequent prop changes.

On first paint of the page, `row.loaded` is still `false` (the row store loads lazily via `expandRow`), so `showInvitation` evaluates to `false`, and the actual placeholder text gets baked in. By the time `row.loaded` flips to `true` and `showInvitation` becomes `true`, the placeholder is already in CodeMirror's state — only the JSX-level `<HorizonInvitation>` is suppressed/shown reactively, the placeholder isn't.

## The fix

Drop the placeholder prop entirely. It's redundant on this page in every realistic case:
- **Empty + no carry-over:** `HorizonInvitation` owns the messaging above.
- **Carry-over present:** editor has carried content, CodeMirror's placeholder doesn't render.
- **Post-clear from carry-over:** `CarryOverBanner` above provides context.

Removed the now-unused `PLACEHOLDER` constant.

## Test plan

- [ ] `/horizon/life-values` (empty) shows *one* "How do you want to live? Begin anywhere." line (the invitation above the editor)
- [ ] `/horizon/life-goals` (empty) shows *one* invitation line
- [ ] Time-bound horizons with carry-over still show the carry-over banner correctly
- [ ] `pnpm test` passes (103 tests)
- [ ] `vp check` passes (format + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)