### PR TITLE
feat(masthead): promote About link for newcomer orientation

### DIFF
--- a/homebase/src/components/Masthead.tsx
+++ b/homebase/src/components/Masthead.tsx
@@ -1,15 +1,17 @@
 // Masthead — the top of the strategic accordion.
 //
-// Three lines of type:
+// Three lines of type, plus a quiet way-in for newcomers:
 //   eyebrow  — "A STRATEGIC LIFE GUIDE"  (Inter Tight 10px, 0.28em tracking)
 //   word     — "Homebase"                 (Newsreader italic 84px)
 //   meta     — dateline                   (Inter Tight 11px, 0.22em tracking)
+//   about    — "ABOUT THIS GUIDE →"       (Inter Tight 10px, 0.22em tracking)
 //
 // Plus a 48px horizontal rule below in --ink-4 to mark the end of the
 // cover register and the start of the table of contents.
 //
 // Per the redesign prototype at ~/dev/homebase/Homebase Redesign/.
 
+import { useNavigate } from "@tanstack/react-router";
 import { PeriodKey } from "../lib/period-key";
 
 const DAYS = ["SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY"];
@@ -29,6 +31,7 @@ const MONTHS = [
 ];
 
 export function Masthead() {
+  const navigate = useNavigate();
   const now = new Date();
   const weekday = DAYS[now.getDay()];
   const date = `${MONTHS[now.getMonth()]} ${now.getDate()}, ${now.getFullYear()}`;
@@ -62,9 +65,18 @@ export function Masthead() {
       >
         {weekday} <span aria-hidden="true">·</span> {date} <span aria-hidden="true">·</span> {week}
       </div>
+      <button
+        type="button"
+        onClick={() => navigate({ to: "/about" })}
+        className="mt-3 inline-flex cursor-pointer items-center gap-2 border-0 bg-transparent p-0 font-sans text-[10px] font-medium uppercase transition-colors hover:text-[var(--ink-1)]"
+        style={{ color: "var(--ink-3)", letterSpacing: "0.22em" }}
+      >
+        About this guide
+        <span aria-hidden="true">→</span>
+      </button>
       <div
         aria-hidden="true"
-        className="mx-auto mt-[22px] mb-9 h-px w-12"
+        className="mx-auto mt-5 mb-9 h-px w-12"
         style={{ background: "var(--ink-4)" }}
       />
     </header>

--- a/homebase/src/routes/index.tsx
+++ b/homebase/src/routes/index.tsx
@@ -41,16 +41,7 @@ function StrategyAccordion() {
               className="font-sans text-[10px] font-medium uppercase"
               style={{ color: "var(--ink-4)", letterSpacing: "0.28em" }}
             >
-              VOL. I <span aria-hidden="true">·</span> HOMEBASE 2026{" "}
-              <span aria-hidden="true">·</span>{" "}
-              <button
-                type="button"
-                onClick={() => navigate({ to: "/about" })}
-                className="cursor-pointer border-0 bg-transparent p-0 transition-colors hover:text-[var(--ink-1)]"
-                style={{ color: "inherit", letterSpacing: "inherit", font: "inherit" }}
-              >
-                About
-              </button>
+              VOL. I <span aria-hidden="true">·</span> HOMEBASE 2026
             </div>
           </footer>
         </div>


### PR DESCRIPTION
## Summary

Promotes the About link from a quiet footer item (--ink-4 ghost color) to a more obvious affordance directly under the dateline in the Masthead.

The placement matters: a first-time visitor lands on the strategic accordion and may not know what they're looking at before clicking into a horizon. The About page exists but was buried.

## Design

Stays inside the editorial register:
- Same Inter Tight uppercase + 0.22em letter-spacing as the dateline above it
- --ink-3 color (matches dateline; not as bright as the body, not as faint as chrome)
- Trailing `→` arrow signals it's a way-in
- 12px gap below dateline, 20px gap to the hairline rule that closes the cover register

Drops the now-redundant footer About link to keep the affordance singular.

```
       A STRATEGIC LIFE GUIDE

            Homebase

  FRIDAY · MAY 8, 2026 · WEEK 19

       ABOUT THIS GUIDE →

       ————————

[ Life values            → ]
[ Life goals             → ]
...
```

## Test plan

- [ ] `/` shows "ABOUT THIS GUIDE →" centered below the dateline, in the same uppercase register
- [ ] Click navigates to `/about`
- [ ] Footer no longer has a duplicate About link
- [ ] `pnpm test` passes (103 tests)
- [ ] `vp check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)