### PR TITLE
chore: set up auto-merge for agent workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,10 @@ Use judgment to plan appropriately for the task:
 
 The branch protection on `main` requires the CI check to pass. Auto-merge is fine once CI is green; the deploy workflow rolls the change to `meninoebom.github.io/homebase/` automatically.
 
+## Auto-merge
+
+PRs in this repo use auto-merge. After creating a PR, run `gh pr merge --auto --squash`. GitHub will hold the merge until the required `check` status reports green, then squash + delete the branch automatically. No babysitting required.
+
 ## Code Quality
 
 - `vp check` (or `pnpm check`) before committing — format + lint + typecheck.


### PR DESCRIPTION
## Summary

Enables auto-merge in this repo so future PRs can ship hands-free once CI is green.

## What was done

- **Repo setting:** `allow_auto_merge=true` enabled via `gh api PATCH`. (Squash merge was already allowed.)
- **Branch protection:** unchanged — `main` already required the `check` status from `.github/workflows/ci.yml`, which is the gate auto-merge needs.
- **CLAUDE.md:** appends a short Auto-merge section so future sessions reach for `gh pr merge --auto --squash` instead of watching CI manually.

## Dogfooding

This very PR uses `gh pr merge --auto --squash`. If everything is wired correctly, CI runs, the merge happens automatically, the branch deletes, and the deploy workflow kicks off — no further intervention needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)