### PR TITLE
feat(strategy): faint collapsed previews + neutral day label

### DIFF
--- a/homebase/src/components/HorizonRow.test.tsx
+++ b/homebase/src/components/HorizonRow.test.tsx
@@ -7,10 +7,10 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { HorizonRow } from "./HorizonRow";
 
 describe("HorizonRow", () => {
-  it("Day row shows 'Open morning ritual' and a → arrow", () => {
+  it("Day row shows 'Open today's page' and a → arrow", () => {
     render(<HorizonRow horizon="day" />);
     expect(screen.getByText("Day")).toBeInTheDocument();
-    expect(screen.getByText("Open morning ritual")).toBeInTheDocument();
+    expect(screen.getByText("Open today's page")).toBeInTheDocument();
     expect(screen.getByText("→")).toBeInTheDocument();
   });
 

--- a/homebase/src/components/HorizonRow.tsx
+++ b/homebase/src/components/HorizonRow.tsx
@@ -20,10 +20,12 @@
 // from the StrategyAccordion route container in #9; tasteful fallbacks
 // live in this component for isolated rendering / tests.
 
+import { useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { CarryOverBanner } from "./CarryOverBanner";
 import { HorizonInvitation } from "./HorizonInvitation";
 import { SectionPreview } from "./SectionPreview";
+import { extractCollapsedPreview } from "../lib/markdown-preview";
 import { PeriodKey, type Horizon } from "../lib/period-key";
 import { useStrategyStore } from "../store/strategy";
 
@@ -47,7 +49,7 @@ const TITLE: Record<Horizon | "day", string> = {
 
 /** Metadata text shown in the header's right column. */
 function metaFor(horizon: Horizon | "day"): string {
-  if (horizon === "day") return "Open morning ritual";
+  if (horizon === "day") return "Open today's page";
   if (horizon === "life-values" || horizon === "life-goals") return "Persistent";
   const key = PeriodKey.current(horizon);
   if (!key) return "";
@@ -145,8 +147,15 @@ function StrategyRow({ horizon }: { horizon: Exclude<Horizon | "day", "day"> }) 
   const navigate = useNavigate();
   const row = useStrategyStore((s) => s.rows[horizon]);
   const expandRow = useStrategyStore((s) => s.expandRow);
+  const prefetchRow = useStrategyStore((s) => s.prefetchRow);
   const collapseRow = useStrategyStore((s) => s.collapseRow);
   const clearCarryOver = useStrategyStore((s) => s.clearCarryOver);
+
+  // Pull saved content into state on mount so collapsed rows can show a
+  // faint preview line. Skips the carry-over resolver — see prefetchRow.
+  useEffect(() => {
+    prefetchRow(horizon).catch(() => {});
+  }, [horizon, prefetchRow]);
 
   const onToggle = () => {
     if (row.expanded) {
@@ -155,6 +164,9 @@ function StrategyRow({ horizon }: { horizon: Exclude<Horizon | "day", "day"> }) 
       expandRow(horizon).catch(() => {});
     }
   };
+
+  const collapsedPreview =
+    !row.expanded && row.content ? extractCollapsedPreview(row.content) : null;
 
   const openEditor = () => {
     navigate({ to: "/horizon/$id", params: { id: horizon } });
@@ -226,6 +238,26 @@ function StrategyRow({ horizon }: { horizon: Exclude<Horizon | "day", "day"> }) 
         >
           +
         </span>
+        {collapsedPreview && (
+          <span
+            className="italic"
+            style={{
+              gridColumn: 2,
+              gridRow: 2,
+              marginTop: "6px",
+              minWidth: 0,
+              fontFamily: "var(--font-serif-text)",
+              fontSize: "14px",
+              lineHeight: 1.4,
+              color: "var(--ink-5)",
+              overflow: "hidden",
+              whiteSpace: "nowrap",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {collapsedPreview}
+          </span>
+        )}
       </button>
 
       {row.expanded && (

--- a/homebase/src/lib/markdown-preview.ts
+++ b/homebase/src/lib/markdown-preview.ts
@@ -44,6 +44,20 @@ export function extractLead(content: string): string | null {
 }
 
 /**
+ * Extract a single-line preview for a *collapsed* row — the very faint
+ * line shown under the title to hint that the section already has saved
+ * writing. Lead paragraph wins; falls back to the first bullet item so
+ * bullet-only sections still show something. Returns null when the file
+ * has no extractable content.
+ */
+export function extractCollapsedPreview(content: string): string | null {
+  const lead = extractLead(content);
+  if (lead) return lead;
+  const [first] = extractItems(content, 1);
+  return first ?? null;
+}
+
+/**
  * Extract top-level bullet items as a flat list of plain strings. Strips
  * GFM checkboxes (`- [ ]` / `- [x]`) so the preview reads as content,
  * not as a checklist with state. Skips nested bullets (anything indented).

--- a/homebase/src/store/strategy.ts
+++ b/homebase/src/store/strategy.ts
@@ -27,6 +27,7 @@ export interface RowState {
 export interface StrategyState {
   rows: Record<Horizon, RowState>;
   expandRow: (horizon: Horizon) => Promise<void>;
+  prefetchRow: (horizon: Horizon) => Promise<void>;
   collapseRow: (horizon: Horizon) => void;
   setContent: (horizon: Horizon, content: string) => void;
   clearCarryOver: (horizon: Horizon) => void;
@@ -125,6 +126,23 @@ export function createStrategyStore(fs: StrategyFsApi): UseBoundStore<StoreApi<S
             // banner dismisses naturally on first edit.
             dirty: carryOver !== null,
           },
+        },
+      }));
+    },
+
+    // Read the file *without* expanding the row, so collapsed rows can
+    // surface a faint preview line. Strictly a file read — never runs the
+    // carry-over resolver, since that's an engagement moment that should
+    // only fire on an explicit expand.
+    prefetchRow: async (horizon) => {
+      if (get().rows[horizon].loaded) return;
+      const file = filenameFor(horizon);
+      const existing = await fs.read(file);
+      if (existing === null) return;
+      set((s) => ({
+        rows: {
+          ...s.rows,
+          [horizon]: { ...s.rows[horizon], content: existing, loaded: true },
         },
       }));
     },


### PR DESCRIPTION
## Summary
- Collapsed strategy rows now show a single faint italic preview line under the title when the section has saved content — at-a-glance hint that there's writing inside, without forcing a click. Lead paragraph wins; first bullet as fallback.
- Adds a `prefetchRow` store action that reads the file without expanding and without running the carry-over resolver — preserves the "first explicit expand" semantics for the carry-over banner.
- Replaces the Day row's "Open morning ritual" with "Open today's page" so the language doesn't assume a morning practice (journalers, night reflectors, etc. are welcome too).

## Test plan
- [x] `pnpm test` (103 passing)
- [x] `pnpm typecheck`
- [ ] In `pnpm dev`: write something into Life goals, collapse it, confirm the faint line appears under the title
- [ ] Confirm the line truncates with ellipsis on long content (doesn't push "Persistent" off-screen)
- [ ] Confirm the Day row reads "Open today's page"
- [ ] Confirm an empty time-bound row (e.g. a fresh Week) still shows the carry-over banner on first expand (prefetch shouldn't have eaten it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)