### PR TITLE
fix(morning): persist day-log content across reloads

### DIFF
--- a/homebase/src/routes/morning.tsx
+++ b/homebase/src/routes/morning.tsx
@@ -22,18 +22,21 @@ function MorningHub() {
   const saving = useRitualStore((s) => s.saving);
   const lastSavedAt = useRitualStore((s) => s.lastSavedAt);
   const drafts = useRitualStore((s) => s.drafts);
+  const loaded = useRitualStore((s) => s.loaded);
 
   useEffect(() => {
     void loadToday();
   }, [loadToday]);
 
-  // Auto-save 800ms after any draft change
+  // Auto-save 800ms after any draft change. Gated on `loaded` so we don't
+  // race-write an empty file before the disk read completes.
   useEffect(() => {
+    if (!loaded) return;
     const timer = setTimeout(() => {
       void saveNow();
     }, 800);
     return () => clearTimeout(timer);
-  }, [drafts, saveNow]);
+  }, [drafts, saveNow, loaded]);
 
   const today = new Date();
   const dateline = today
@@ -66,27 +69,28 @@ function MorningHub() {
           </p>
         </div>
 
-        {slotOrder.map((slotId, i) => {
-          const slot = getSlot(slotId);
-          if (!slot) return null;
-          const SlotComponent = slot.component;
-          const title = SECTION_TITLES[slotId];
+        {loaded &&
+          slotOrder.map((slotId, i) => {
+            const slot = getSlot(slotId);
+            if (!slot) return null;
+            const SlotComponent = slot.component;
+            const title = SECTION_TITLES[slotId];
 
-          return (
-            <section key={slotId} className={i > 0 ? "mt-4 border-t border-[#EBEBEB] pt-3" : ""}>
-              {title && (
-                <h2 className="mb-1 font-serif text-[17px] font-light italic text-[#111]">
-                  {title}
-                </h2>
-              )}
-              <SlotComponent
-                mode="morning"
-                initialDraft={drafts[slotId] ?? ""}
-                onDraft={(body) => setDraft(slotId, body)}
-              />
-            </section>
-          );
-        })}
+            return (
+              <section key={slotId} className={i > 0 ? "mt-4 border-t border-[#EBEBEB] pt-3" : ""}>
+                {title && (
+                  <h2 className="mb-1 font-serif text-[17px] font-light italic text-[#111]">
+                    {title}
+                  </h2>
+                )}
+                <SlotComponent
+                  mode="morning"
+                  initialDraft={drafts[slotId] ?? ""}
+                  onDraft={(body) => setDraft(slotId, body)}
+                />
+              </section>
+            );
+          })}
       </div>
 
       <footer className="sticky bottom-0 flex items-center justify-end border-t border-[#EBEBEB] bg-white px-6 py-1.5">

--- a/homebase/src/store/ritual.ts
+++ b/homebase/src/store/ritual.ts
@@ -11,6 +11,7 @@ export type SlotId = string;
 
 interface RitualState {
   drafts: Record<SlotId, string>;
+  loaded: boolean;
   saving: boolean;
   lastSavedAt: number | null;
 
@@ -21,12 +22,17 @@ interface RitualState {
 
 export const useRitualStore = create<RitualState>()((set, get) => ({
   drafts: {},
+  loaded: false,
   saving: false,
   lastSavedAt: null,
 
   loadToday: async () => {
     const sections = await readDaySections(todayISO());
-    set({ drafts: sections });
+    // CodeMirror is uncontrolled: each RitualEditor seeds its doc once at
+    // mount from initialContent. If we render slots before `loaded` is true,
+    // every editor gets an empty doc and never picks up the disk content
+    // when it arrives — silent data loss on each new tab.
+    set({ drafts: sections, loaded: true });
   },
 
   setDraft: (slotId, body) => {


### PR DESCRIPTION
## Summary
Fresh tabs of `/morning` were showing prompt placeholders instead of saved entries for Inner Weather, Morning Practices, Today, and Creative Projects. The data was on disk — it just never reached the editor.

**Root cause:** `RitualEditor` is uncontrolled — CodeMirror seeds its doc once from `initialContent` at mount, with `[]` deps explicitly disabled by an `eslint-disable-next-line`. The morning hub rendered all slots immediately and fired `loadToday()` afterward, so every editor mounted with empty content and never picked up the disk read when it resolved.

**Fix:** Track a `loaded` flag in the ritual store, set `true` once `loadToday()` resolves, and gate the slot render on it so editors only mount once they have the right initial content. The auto-save effect is gated too so we don't race-write an empty file before the disk read settles.

Piano (workspace slot, different code path) and the weekly-goals carry-over (rendered as static text, no editor) were already persisting fine — both are unaffected.

## Test plan
- [x] `pnpm test` (103 passing)
- [x] `pnpm typecheck`
- [ ] Write something into Inner Weather, save, reload — content reappears
- [ ] Same for Morning Practices, Today, Creative Projects
- [ ] Confirm there's no flicker/flash of empty content during the load
- [ ] Confirm Piano still works
- [ ] Confirm a brand-new day (no file yet) shows the prompts (not blank editors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)