### PR TITLE
feat(config): schema, parse/serialize, validation, defaults (closes #46)

### DIFF
--- a/homebase/src/lib/config.test.ts
+++ b/homebase/src/lib/config.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  defaultConfig,
+  legacyDefaultConfig,
+  parseConfig,
+  serializeConfig,
+  validateConfig,
+  type HomebaseConfig,
+} from "./config";
+
+describe("validateConfig", () => {
+  it("accepts the defaultConfig", () => {
+    expect(validateConfig(defaultConfig()).kind).toBe("ok");
+  });
+
+  it("accepts the legacyDefaultConfig", () => {
+    expect(validateConfig(legacyDefaultConfig()).kind).toBe("ok");
+  });
+
+  it("rejects non-objects", () => {
+    expect(validateConfig(null).kind).toBe("schema-error");
+    expect(validateConfig("string").kind).toBe("schema-error");
+    expect(validateConfig([]).kind).toBe("schema-error");
+  });
+
+  it("rejects wrong version", () => {
+    const result = validateConfig({ ...defaultConfig(), version: 2 });
+    expect(result.kind).toBe("schema-error");
+    if (result.kind === "schema-error") {
+      expect(result.issues.some((i) => i.includes("version"))).toBe(true);
+    }
+  });
+
+  it("rejects an empty slots array", () => {
+    const result = validateConfig({ ...defaultConfig(), slots: [] });
+    expect(result.kind).toBe("schema-error");
+    if (result.kind === "schema-error") {
+      expect(result.issues.some((i) => i.includes("at least one"))).toBe(true);
+    }
+  });
+
+  it("rejects duplicate slot ids", () => {
+    const config = {
+      ...defaultConfig(),
+      slots: [
+        { id: "x", kind: "prompt", prompt: "a" },
+        { id: "x", kind: "prompt", prompt: "b" },
+      ],
+    };
+    const result = validateConfig(config);
+    expect(result.kind).toBe("schema-error");
+    if (result.kind === "schema-error") {
+      expect(result.issues.some((i) => i.includes("duplicated"))).toBe(true);
+    }
+  });
+
+  it("rejects bad id formats", () => {
+    const cases = ["UpperCase", "with space", "with/slash", "-leading-dash", ""];
+    for (const id of cases) {
+      const result = validateConfig({
+        ...defaultConfig(),
+        slots: [{ id, kind: "prompt", prompt: "p" }],
+      });
+      expect(result.kind, `id "${id}" should be rejected`).toBe("schema-error");
+    }
+  });
+
+  it("accepts well-formed slot ids", () => {
+    const cases = ["dreams", "inner-weather", "x", "1", "slot-1", "0-thing"];
+    for (const id of cases) {
+      const result = validateConfig({
+        ...defaultConfig(),
+        slots: [{ id, kind: "prompt", prompt: "p" }],
+      });
+      expect(result.kind, `id "${id}" should be accepted`).toBe("ok");
+    }
+  });
+
+  it("rejects unknown slot kinds", () => {
+    const result = validateConfig({
+      ...defaultConfig(),
+      slots: [{ id: "x", kind: "mystery", prompt: "p" }],
+    });
+    expect(result.kind).toBe("schema-error");
+    if (result.kind === "schema-error") {
+      expect(result.issues.some((i) => i.includes('"prompt" or "workspace"'))).toBe(true);
+    }
+  });
+
+  it("requires title on workspace slots", () => {
+    const result = validateConfig({
+      ...defaultConfig(),
+      slots: [{ id: "p", kind: "workspace" }],
+    });
+    expect(result.kind).toBe("schema-error");
+  });
+
+  it("allows missing title on prompt slots", () => {
+    const result = validateConfig({
+      ...defaultConfig(),
+      slots: [{ id: "p", kind: "prompt", prompt: "ok" }],
+    });
+    expect(result.kind).toBe("ok");
+  });
+
+  it("rejects malformed briefing", () => {
+    const result = validateConfig({
+      ...defaultConfig(),
+      briefing: { enabled: "yes", quotes: [1, 2, 3] },
+    });
+    expect(result.kind).toBe("schema-error");
+  });
+
+  it("rejects hints that aren't string arrays", () => {
+    const result = validateConfig({
+      ...defaultConfig(),
+      slots: [{ id: "p", kind: "prompt", prompt: "p", hints: [1, 2] }],
+    });
+    expect(result.kind).toBe("schema-error");
+  });
+});
+
+describe("parseConfig", () => {
+  it("returns parse-error for invalid JSON", () => {
+    const result = parseConfig("{not json}");
+    expect(result.kind).toBe("parse-error");
+    if (result.kind === "parse-error") {
+      expect(result.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns ok for valid config JSON", () => {
+    const json = serializeConfig(defaultConfig());
+    expect(parseConfig(json).kind).toBe("ok");
+  });
+
+  it("returns schema-error for valid JSON with bad shape", () => {
+    expect(parseConfig('{"version": 99}').kind).toBe("schema-error");
+  });
+});
+
+describe("serializeConfig", () => {
+  it("round-trips through parseConfig", () => {
+    const original = legacyDefaultConfig();
+    const json = serializeConfig(original);
+    const parsed = parseConfig(json);
+    expect(parsed.kind).toBe("ok");
+    if (parsed.kind === "ok") {
+      expect(parsed.config).toEqual(original);
+    }
+  });
+
+  it("produces pretty-printed JSON ending in a newline", () => {
+    const json = serializeConfig(defaultConfig());
+    expect(json.endsWith("\n")).toBe(true);
+    expect(json).toContain("\n  ");
+  });
+});
+
+describe("defaultConfig", () => {
+  it("ships at least one slot and no Piano", () => {
+    const config = defaultConfig();
+    expect(config.slots.length).toBeGreaterThan(0);
+    expect(config.slots.find((s) => s.id === "piano")).toBeUndefined();
+  });
+
+  it("has briefing enabled with no quotes (so renders nothing until user adds them)", () => {
+    const config = defaultConfig();
+    expect(config.briefing.enabled).toBe(true);
+    expect(config.briefing.quotes).toEqual([]);
+  });
+});
+
+describe("legacyDefaultConfig", () => {
+  it("includes piano as a workspace slot", () => {
+    const piano = legacyDefaultConfig().slots.find((s) => s.id === "piano");
+    expect(piano?.kind).toBe("workspace");
+  });
+
+  it("includes the existing briefing quote so Brandon's setup looks identical post-migration", () => {
+    const config = legacyDefaultConfig();
+    expect(config.briefing.quotes.length).toBeGreaterThan(0);
+  });
+});
+
+describe("type narrowing", () => {
+  it("narrows by kind via discriminated union", () => {
+    const config: HomebaseConfig = legacyDefaultConfig();
+    for (const slot of config.slots) {
+      if (slot.kind === "prompt") {
+        expect(typeof slot.prompt).toBe("string");
+      } else if (slot.kind === "workspace") {
+        expect(typeof slot.title).toBe("string");
+      }
+    }
+  });
+});

--- a/homebase/src/lib/config.ts
+++ b/homebase/src/lib/config.ts
@@ -1,0 +1,293 @@
+// homebase.config.json — schema, defaults, validation, and disk I/O.
+//
+// The config lives in the user's log directory next to their day files.
+// It travels with the data: backups include it, switching machines means
+// re-picking the folder and the config follows automatically. There is
+// no sync layer because there is nothing to sync.
+//
+// Slot ids are stable: they're written into day-file headers (## piano)
+// and renaming would orphan history. Display titles are mutable; ids
+// are not. The settings UI exposes title only; ids are read-only.
+
+import { readFile, writeFile } from "./fs";
+
+export const CONFIG_FILENAME = "homebase.config.json";
+
+// -- Types --------------------------------------------------------------
+
+export interface HomebaseConfig {
+  version: 1;
+  slots: SlotConfig[];
+  briefing: BriefingConfig;
+}
+
+export type SlotConfig = PromptSlotConfig | WorkspaceSlotConfig;
+
+export interface PromptSlotConfig {
+  id: string;
+  kind: "prompt";
+  title?: string;
+  prompt: string;
+  hints?: string[];
+}
+
+export interface WorkspaceSlotConfig {
+  id: string;
+  kind: "workspace";
+  title: string;
+  stateLabel?: string;
+  prompt?: string;
+}
+
+export interface BriefingConfig {
+  enabled: boolean;
+  quotes: string[];
+}
+
+// -- Read / write result types ------------------------------------------
+
+export type ReadConfigResult =
+  | { kind: "ok"; config: HomebaseConfig }
+  | { kind: "missing" }
+  | { kind: "parse-error"; message: string }
+  | { kind: "schema-error"; issues: string[] };
+
+// -- Validation ---------------------------------------------------------
+
+const ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Validate a parsed-JSON value against the HomebaseConfig schema.
+ * Returns either a typed config or the list of issues — never throws.
+ */
+export function validateConfig(
+  value: unknown,
+): { kind: "ok"; config: HomebaseConfig } | { kind: "schema-error"; issues: string[] } {
+  const issues: string[] = [];
+
+  if (!isObject(value)) {
+    return { kind: "schema-error", issues: ["config must be a JSON object"] };
+  }
+
+  if (value.version !== 1) {
+    issues.push(`unsupported version: expected 1, got ${JSON.stringify(value.version)}`);
+  }
+
+  if (!Array.isArray(value.slots)) {
+    issues.push("slots must be an array");
+  } else if (value.slots.length === 0) {
+    issues.push("slots must contain at least one entry");
+  } else {
+    const seenIds = new Set<string>();
+    value.slots.forEach((slot, i) => {
+      validateSlot(slot, i, seenIds, issues);
+    });
+  }
+
+  if (!isObject(value.briefing)) {
+    issues.push("briefing must be an object");
+  } else {
+    if (typeof value.briefing.enabled !== "boolean") {
+      issues.push("briefing.enabled must be a boolean");
+    }
+    if (
+      !Array.isArray(value.briefing.quotes) ||
+      !value.briefing.quotes.every((q) => typeof q === "string")
+    ) {
+      issues.push("briefing.quotes must be an array of strings");
+    }
+  }
+
+  if (issues.length > 0) {
+    return { kind: "schema-error", issues };
+  }
+
+  return { kind: "ok", config: value as unknown as HomebaseConfig };
+}
+
+function validateSlot(slot: unknown, index: number, seenIds: Set<string>, issues: string[]): void {
+  const at = `slots[${index}]`;
+  if (!isObject(slot)) {
+    issues.push(`${at} must be an object`);
+    return;
+  }
+
+  if (typeof slot.id !== "string") {
+    issues.push(`${at}.id must be a string`);
+  } else if (!ID_PATTERN.test(slot.id)) {
+    issues.push(
+      `${at}.id "${slot.id}" must match /^[a-z0-9][a-z0-9-]*$/ — lowercase letters, digits, and hyphens only, must start with letter or digit`,
+    );
+  } else if (seenIds.has(slot.id)) {
+    issues.push(`${at}.id "${slot.id}" is duplicated`);
+  } else {
+    seenIds.add(slot.id);
+  }
+
+  if (slot.kind === "prompt") {
+    if (typeof slot.prompt !== "string") {
+      issues.push(`${at}.prompt must be a string`);
+    }
+    if (slot.title !== undefined && typeof slot.title !== "string") {
+      issues.push(`${at}.title must be a string when present`);
+    }
+    if (slot.hints !== undefined) {
+      if (!Array.isArray(slot.hints) || !slot.hints.every((h) => typeof h === "string")) {
+        issues.push(`${at}.hints must be an array of strings when present`);
+      }
+    }
+  } else if (slot.kind === "workspace") {
+    if (typeof slot.title !== "string" || slot.title.length === 0) {
+      issues.push(`${at}.title is required for workspace slots`);
+    }
+    if (slot.stateLabel !== undefined && typeof slot.stateLabel !== "string") {
+      issues.push(`${at}.stateLabel must be a string when present`);
+    }
+    if (slot.prompt !== undefined && typeof slot.prompt !== "string") {
+      issues.push(`${at}.prompt must be a string when present`);
+    }
+  } else {
+    issues.push(`${at}.kind must be "prompt" or "workspace"`);
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// -- Parse / serialize --------------------------------------------------
+
+/** Parse a config JSON string. Returns ok / parse-error / schema-error. */
+export function parseConfig(json: string): ReadConfigResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err) {
+    return {
+      kind: "parse-error",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+  return validateConfig(parsed);
+}
+
+/** Pretty-print a config to JSON with 2-space indentation. */
+export function serializeConfig(config: HomebaseConfig): string {
+  return JSON.stringify(config, null, 2) + "\n";
+}
+
+// -- Defaults -----------------------------------------------------------
+
+/**
+ * Neutral starter config for fresh users (empty log dir).
+ * No Piano. No Brandon-isms. Four slots that imply a journaling
+ * practice without prescribing one.
+ */
+export function defaultConfig(): HomebaseConfig {
+  return {
+    version: 1,
+    slots: [
+      {
+        id: "dreams",
+        kind: "prompt",
+        prompt: "What did you dream?",
+      },
+      {
+        id: "inner-weather",
+        kind: "prompt",
+        title: "Inner Weather",
+        prompt: "What's alive in you this morning?",
+        hints: ["weighing on you", "needs to be said", "giving you life", "gratitude"],
+      },
+      {
+        id: "gratitude",
+        kind: "prompt",
+        title: "Gratitude",
+        prompt: "What are you grateful for today?",
+      },
+      {
+        id: "today",
+        kind: "prompt",
+        title: "Today",
+        prompt: "What do you want to do today?",
+      },
+    ],
+    briefing: {
+      enabled: true,
+      quotes: [],
+    },
+  };
+}
+
+/**
+ * Existing-user migration: mirrors the current hardcoded slot registry
+ * verbatim (Dreams · Inner Weather · Morning Practices · Piano · Creative
+ * · Orient). Only used when a log dir already contains day files but no
+ * config — Brandon's setup, anyone migrating from a pre-config build.
+ */
+export function legacyDefaultConfig(): HomebaseConfig {
+  return {
+    version: 1,
+    slots: [
+      {
+        id: "dreams",
+        kind: "prompt",
+        prompt: "What did you dream?",
+      },
+      {
+        id: "inner-weather",
+        kind: "prompt",
+        title: "Inner Weather",
+        prompt: "What's alive in you this morning?",
+        hints: ["weighing on you", "avoiding", "needs to be said", "giving you life", "gratitude"],
+      },
+      {
+        id: "morning-practices",
+        kind: "prompt",
+        title: "Morning Practices",
+        prompt: "Anything about your practices today?",
+        hints: ["movement", "meditation", "water", "piano"],
+      },
+      {
+        id: "piano",
+        kind: "workspace",
+        title: "Piano",
+        stateLabel: "Goals",
+      },
+      {
+        id: "creative",
+        kind: "prompt",
+        title: "Creative Projects",
+        prompt: "What's surfacing? What's maturing?",
+      },
+      {
+        id: "orient",
+        kind: "prompt",
+        title: "Orient",
+        prompt: "What's the shape of your day?",
+      },
+    ],
+    briefing: {
+      enabled: true,
+      quotes: ["The only way to do great work is to love what you do."],
+    },
+  };
+}
+
+// -- Disk I/O -----------------------------------------------------------
+
+/**
+ * Read homebase.config.json from the log dir.
+ * Returns "missing" when the file doesn't exist (or is empty —
+ * empty file == user error, regenerate defaults rather than crash).
+ */
+export async function readConfig(): Promise<ReadConfigResult> {
+  const raw = await readFile(CONFIG_FILENAME);
+  if (raw === "") return { kind: "missing" };
+  return parseConfig(raw);
+}
+
+/** Write homebase.config.json to the log dir. */
+export async function writeConfig(config: HomebaseConfig): Promise<void> {
+  await writeFile(CONFIG_FILENAME, serializeConfig(config));
+}


### PR DESCRIPTION
## Summary
Foundation for the configurability epic ([#45](https://github.com/meninoebom/homebase/issues/45)). Ships only the data layer — no UI changes, no behavior changes. Subsequent issues build on this.

- **`HomebaseConfig` schema** — two slot kinds (`prompt`, `workspace`) + a `briefing` block. Stable slot ids that match day-file `##` headers.
- **Hand-rolled validator** (no Zod dep) — returns a discriminated result so callers can render parse-errors vs. schema-errors vs. missing-file separately.
- **`defaultConfig()`** — neutral starter for fresh users (Dreams, Inner Weather, Gratitude, Today; no Piano).
- **`legacyDefaultConfig()`** — Brandon's current hardcoded slots verbatim, used in #48 to migrate the existing log dir without behavior changes.
- **`readConfig()` / `writeConfig()`** — wrap `lib/fs.ts`; `CONFIG_FILENAME` lives next to day files.

## Test plan
- [x] `pnpm test` (23 new tests; 126 total passing)
- [x] `pnpm typecheck`
- [x] Validator covers: duplicate ids, bad id formats, empty slots array, wrong version, malformed briefing, hints array shape, unknown slot kinds, missing workspace title
- [x] `parseConfig` returns `parse-error` for bad JSON, `schema-error` for valid-JSON-bad-shape, `ok` for valid
- [x] `serializeConfig` round-trips through `parseConfig`
- [x] Both default configs validate clean

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)