### PR TITLE
feat(settings): empty state + reset-to-defaults + recovery polish (closes #52, #45)

### DIFF
--- a/homebase/src/routes/morning.tsx
+++ b/homebase/src/routes/morning.tsx
@@ -62,6 +62,10 @@ function MorningHub() {
 
         {loaded && config && <BriefingPanel config={config} />}
 
+        {loaded && config && config.slots.length === 0 && (
+          <EmptyState onCustomize={() => navigate({ to: "/settings" })} />
+        )}
+
         {loaded &&
           config?.slots.map((slot, i) => (
             <section key={slot.id} className={i > 0 ? "mt-4 border-t border-[#EBEBEB] pt-3" : ""}>
@@ -92,6 +96,23 @@ function MorningHub() {
         </span>
       </footer>
     </main>
+  );
+}
+
+function EmptyState({ onCustomize }: { onCustomize: () => void }) {
+  return (
+    <div className="mt-12 flex flex-col items-center gap-4 rounded border border-dashed border-[#E5E7EB] px-6 py-12 text-center">
+      <p className="font-serif text-[16px] italic text-[#6B7280]">
+        Your homebase has no slots yet.
+      </p>
+      <button
+        type="button"
+        onClick={onCustomize}
+        className="cursor-pointer rounded bg-[#111] px-4 py-2 font-sans text-[13px] font-medium text-white hover:bg-[#374151]"
+      >
+        Customize your homebase →
+      </button>
+    </div>
   );
 }
 
@@ -157,6 +178,13 @@ function ConfigRecoveryScreen({
         <p className="mb-3 font-serif text-[15px] leading-relaxed text-[#374151]">
           The file <code className="font-mono text-[13px]">homebase.config.json</code> in your log
           directory couldn't be loaded. Until it's fixed or reset, the morning page can't render.
+        </p>
+
+        <p className="mb-3 font-sans text-[11px] uppercase tracking-[0.14em] text-[#9CA3AF]">
+          {error.kind === "parse-error" ? "Parse error" : "Schema error"} ·{" "}
+          <span className="lowercase tracking-normal text-[#6B7280]">
+            you can also fix this by editing the file directly in any text editor
+          </span>
         </p>
 
         {error.kind === "parse-error" ? (

--- a/homebase/src/routes/settings.tsx
+++ b/homebase/src/routes/settings.tsx
@@ -49,6 +49,7 @@ function SettingsPage() {
   const loaded = useRitualStore((s) => s.loaded);
   const loadToday = useRitualStore((s) => s.loadToday);
   const updateConfig = useRitualStore((s) => s.updateConfig);
+  const resetToDefaults = useRitualStore((s) => s.resetToDefaults);
 
   useEffect(() => {
     if (!loaded) void loadToday();
@@ -131,8 +132,56 @@ function SettingsPage() {
           briefing={config.briefing}
           onChange={(next) => void updateConfig((c) => ({ ...c, briefing: next }))}
         />
+
+        <ResetSection onReset={() => void resetToDefaults()} />
       </div>
     </main>
+  );
+}
+
+function ResetSection({ onReset }: { onReset: () => void }) {
+  const [confirming, setConfirming] = useState(false);
+
+  if (confirming) {
+    return (
+      <div className="mt-16 rounded border border-[#FECACA] bg-[#FEF2F2] p-4">
+        <p className="mb-3 font-serif text-[14px] leading-relaxed text-[#991B1B]">
+          Reset to defaults? This will replace your current slots and briefing with the standard
+          starter set. Your day-file content will be left alone.
+        </p>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setConfirming(false);
+              onReset();
+            }}
+            className="cursor-pointer rounded bg-[#B91C1C] px-3 py-1.5 font-sans text-[13px] text-white hover:bg-[#991B1B]"
+          >
+            Yes, reset
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            className="cursor-pointer rounded border border-[#E5E7EB] bg-white px-3 py-1.5 font-sans text-[13px] text-[#374151] hover:bg-[#F3F4F6]"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-16 flex justify-center">
+      <button
+        type="button"
+        onClick={() => setConfirming(true)}
+        className="cursor-pointer border-0 bg-transparent p-1 font-sans text-[12px] text-[#9CA3AF] hover:text-[#B91C1C]"
+      >
+        Reset to defaults
+      </button>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Closes the configurability epic [#45](https://github.com/meninoebom/homebase/issues/45). Three pieces of polish:

1. **Morning page empty state** — when the user removes all slots, instead of rendering a blank page, show a friendly panel with a "Customize your homebase →" CTA linking to `/settings`.

2. **Reset-to-defaults action in `/settings`** — small low-emphasis link at the bottom; click reveals an inline confirm panel; confirming writes \`defaultConfig()\` and reloads. Day-file content is preserved (only the config file is overwritten).

3. **Recovery-screen polish** — labels parse-error vs schema-error, adds the "you can also fix this by editing the file directly" hint.

## Deliberately out of scope

The unknown-slot-kind path: a config with \`"kind": "future-thing"\` still falls through the schema-error recovery flow rather than rendering as a placeholder row in settings. Cross-version imports are rare for a personal app, and the recovery + hand-edit affordances are sufficient. Easy to add later by relaxing the validator.

## Test plan

- [x] \`pnpm test\` (147 passing)
- [x] \`pnpm typecheck\`
- [x] \`pnpm check\`
- [x] \`pnpm build\`
- [ ] Manual: in /settings, remove every slot one by one; once empty, navigate to /morning, confirm empty state appears with working "Customize" link
- [ ] Manual: in /settings, click "Reset to defaults", click "Yes, reset", confirm the page reloads with the standard slot set (Dreams · Inner Weather · Gratitude · Today)
- [ ] Manual: corrupt homebase.config.json (e.g. trailing comma), reload /morning, confirm recovery screen shows the parse error message with the editor-hint copy

Closes #52.
Closes #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)