### PR TITLE
chore(daily): rename morning page → daily page + add Home link

### DIFF
--- a/homebase/src/lib/config.ts
+++ b/homebase/src/lib/config.ts
@@ -180,8 +180,9 @@ export function serializeConfig(config: HomebaseConfig): string {
 
 /**
  * Neutral starter config for fresh users (empty log dir).
- * No Piano. No Brandon-isms. Four slots that imply a journaling
- * practice without prescribing one.
+ * No Piano. No Brandon-isms. Time-of-day-neutral copy: someone who
+ * uses Homebase as an evening journal or a midday check-in shouldn't
+ * trip over "this morning" prompts.
  */
 export function defaultConfig(): HomebaseConfig {
   return {
@@ -196,7 +197,7 @@ export function defaultConfig(): HomebaseConfig {
         id: "inner-weather",
         kind: "prompt",
         title: "Inner Weather",
-        prompt: "What's alive in you this morning?",
+        prompt: "What's alive in you right now?",
         hints: ["weighing on you", "needs to be said", "giving you life", "gratitude"],
       },
       {
@@ -209,7 +210,7 @@ export function defaultConfig(): HomebaseConfig {
         id: "today",
         kind: "prompt",
         title: "Today",
-        prompt: "What do you want to do today?",
+        prompt: "What's on your mind today?",
       },
     ],
     briefing: {

--- a/homebase/src/routes/morning.tsx
+++ b/homebase/src/routes/morning.tsx
@@ -58,7 +58,16 @@ function MorningHub() {
   return (
     <main className="min-h-screen bg-white">
       <div className="mx-auto max-w-[780px] px-8 pb-12 pt-6">
-        <p className="mb-4 font-sans text-[11px] tracking-[0.1em] text-[#9CA3AF]">{dateline}</p>
+        <div className="mb-4 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => navigate({ to: "/" })}
+            className="cursor-pointer border-0 bg-transparent p-0 font-sans text-[11px] uppercase tracking-[0.18em] text-[#9CA3AF] hover:text-[#111]"
+          >
+            ← Homebase
+          </button>
+          <p className="font-sans text-[11px] tracking-[0.1em] text-[#9CA3AF]">{dateline}</p>
+        </div>
 
         {loaded && config && <BriefingPanel config={config} />}
 
@@ -177,7 +186,7 @@ function ConfigRecoveryScreen({
         </h1>
         <p className="mb-3 font-serif text-[15px] leading-relaxed text-[#374151]">
           The file <code className="font-mono text-[13px]">homebase.config.json</code> in your log
-          directory couldn't be loaded. Until it's fixed or reset, the morning page can't render.
+          directory couldn't be loaded. Until it's fixed or reset, your daily page can't render.
         </p>
 
         <p className="mb-3 font-sans text-[11px] uppercase tracking-[0.14em] text-[#9CA3AF]">

--- a/homebase/src/routes/settings.tsx
+++ b/homebase/src/routes/settings.tsx
@@ -113,7 +113,7 @@ function SettingsPage() {
         </p>
 
         <h2 className="mb-3 font-sans text-[10px] font-medium uppercase tracking-[0.18em] text-[#9CA3AF]">
-          Your morning page
+          Your daily page
         </h2>
 
         <SlotList
@@ -226,7 +226,7 @@ function BriefingSection({
           onChange={(e) => onChange({ ...briefing, enabled: e.target.checked })}
           className="h-4 w-4"
         />
-        Show a daily quote at the top of the morning page
+        Show a daily quote at the top of your daily page
       </label>
 
       <div className="mt-4">
@@ -239,7 +239,7 @@ function BriefingSection({
           rows={6}
           placeholder={
             briefing.quotes.length === 0
-              ? "Add quotes you want to see in the morning. One rotates in each day."
+              ? "Add quotes you want to see each day. One rotates in by date."
               : ""
           }
           className="w-full resize-y rounded border border-[#E5E7EB] bg-white px-2 py-1 font-serif text-[14px] leading-snug focus:border-[#9CA3AF] focus:outline-none"


### PR DESCRIPTION
## Summary

Three small follow-ups to the configurability epic, based on your feedback:

1. **"Daily page" instead of "morning page"** in user-facing copy. The internal `/morning` URL stays put to keep deep links and the strategy accordion's Day-row nav working — but every place a user reads "morning" now reads "daily" or stays neutral.

2. **"← Homebase" link** at the top-left of the daily page. Sits next to the dateline. No more relying on browser back to get to the strategic accordion.

3. **Time-of-day-neutral defaults** in `defaultConfig()` so evening journalers and night reflectors don't trip over "this morning" prompts:
   - Inner Weather: "What's alive in you **this morning**?" → "**right now**?"
   - Today: "What do you want to **do** today?" → "**What's on your mind** today?"

`legacyDefaultConfig()` is intentionally not updated — it's a snapshot of your pre-config slots used only for first-run migration, and your `homebase.config.json` is already on disk anyway, so the change wouldn't reach you.

## Confirmed: Piano is NOT in defaults

`defaultConfig()` ships Dreams · Inner Weather · Gratitude · Today. New users never see Piano. You see it because the config migration wrote your existing slots to disk on first load — that's working as intended.

## Test plan

- [x] `pnpm test` (147 passing)
- [x] `pnpm typecheck`
- [x] `pnpm check`
- [x] `pnpm build`
- [ ] Manual: open /morning, confirm "← Homebase" link top-left, click → goes to /
- [ ] Manual: open /settings, confirm header reads "Your daily page" + briefing copy uses "daily"
- [ ] Manual: open in a fresh empty folder, confirm Inner Weather prompt reads "right now" not "this morning"

🤖 Generated with [Claude Code](https://claude.com/claude-code)