### PR TITLE
chore: open-source onboarding (LICENSE, README rewrite, CONTRIBUTING, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Something is broken or behaving unexpectedly
+title: ""
+labels: bug
+---
+
+## What happened
+
+<!-- A clear description of what went wrong. -->
+
+## What you expected
+
+<!-- What you thought would happen instead. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- **Browser:** (Chrome / Edge / Brave / Arc — version if you have it)
+- **OS:** (macOS / Windows / Linux)
+- **Live site or local dev:** (https://meninoebom.github.io/homebase/ or `pnpm dev`)
+
+## Anything in your homebase.config.json
+
+<!--
+If the bug seems config-related, paste the relevant slice. Skip if not.
+-->
+
+```json
+```
+
+## Console errors / screenshots
+
+<!-- Open DevTools → Console. Paste anything red. Drag in screenshots. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/meninoebom/homebase/discussions
+    about: For "how does X work" or "would you accept a PR that does Y", use Discussions.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Something you'd like Homebase to do that it currently doesn't
+title: ""
+labels: enhancement
+---
+
+## What you want to do
+
+<!-- Tell me what you're trying to accomplish, before sketching how. -->
+
+## Why it matters
+
+<!-- A short reason. "I journal at night and the morning copy doesn't fit" is enough. -->
+
+## A proposed approach (optional)
+
+<!-- If you have an idea for how it should work, sketch it. Otherwise leave blank. -->
+
+## Anything you've already tried
+
+<!-- Customizing your config? A workaround? Helps me understand the gap. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Thanks for the PR! A few prompts to help reviewers:
+-->
+
+## Summary
+
+<!-- What does this change, and why? Aim for 2–4 bullets. -->
+
+-
+
+## Test plan
+
+<!-- What did you do to convince yourself it works? Check what applies. -->
+
+- [ ] `pnpm test` passes
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm check` passes
+- [ ] Manually verified in the browser
+- [ ] N/A (docs / config only)
+
+## Screenshots
+
+<!-- For UI changes — before/after if possible. Drag images in here. -->
+
+## Notes for the reviewer
+
+<!-- Anything you're unsure about, or want a second opinion on. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to Homebase
+
+Thanks for your interest in helping. Homebase is a small personal-tool project — the bar for "useful contribution" is low, and the bar for "fits the vibe" is mainly about taste, not credentials.
+
+## Ways to help
+
+- **Report bugs you hit.** Use the [bug template](https://github.com/meninoebom/homebase/issues/new?template=bug.md). What you expected, what happened, what browser, what folder you picked, what was in the config file if relevant.
+- **Open feature requests.** Use the [feature template](https://github.com/meninoebom/homebase/issues/new?template=feature.md). Tell me what you want to do that you currently can't, before sketching how it should work.
+- **Pick up a [`good first issue`](https://github.com/meninoebom/homebase/labels/good%20first%20issue).** These are scoped narrowly enough that someone unfamiliar with the codebase can land a PR.
+- **Improve the docs.** README, About page, in-code comments — all fair game.
+- **Translate the default prompts.** Right now defaults ship in English. Adding a non-English starter config is genuinely useful.
+
+## Development setup
+
+Requires Node 20+ and `pnpm` (Corepack works: `corepack enable`).
+
+```bash
+git clone https://github.com/meninoebom/homebase.git
+cd homebase
+pnpm install
+pnpm dev          # Vite dev server at http://localhost:47823
+```
+
+Open the dev URL in a Chromium browser (Homebase uses the File System Access API). Pick a scratch folder for your local data — don't point dev at your real homebase folder unless you mean to.
+
+Daily commands (run from the repo root):
+
+```bash
+pnpm dev          # Vite dev server at http://localhost:47823
+pnpm test         # vitest run once
+pnpm test:watch   # vitest watch mode
+pnpm typecheck    # tsc --noEmit
+pnpm check        # format + lint
+pnpm check:fix    # auto-fix
+pnpm build        # production build to homebase/dist/
+```
+
+## Conventions
+
+### Branches and PRs
+
+- Branch off `main`. Feature branches are named like `feature/foo`, `fix/bar`, `chore/baz`, `docs/qux`.
+- Open a PR with a clear title and a short description. Include a "Test plan" — what you did to convince yourself it works.
+- CI must pass before merge: format, lint, typecheck, tests. Branch protection enforces it.
+- Auto-merge is the default. Once your PR is green and approved, GitHub squash-merges and deletes the branch.
+
+### Commits
+
+- Conventional-commit style for the title (`feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`).
+- Body explains the *why*, not the *what* — the diff is the what.
+
+### Code style
+
+- TypeScript everywhere. No `any` without a justification comment.
+- React 19 with hooks. No class components.
+- Tailwind for styling, with the editorial-cream tokens scoped to `.strategy-scope` and a separate white register for the daily page. See [`homebase/src/index.css`](homebase/src/index.css).
+- Tests live next to the code (`Foo.tsx` + `Foo.test.tsx`) and use `vitest` + `@testing-library/react`.
+- Run `pnpm check` before pushing. CI rejects unformatted code.
+
+### Comments
+
+- Default to *no* comments. Only add a comment when the *why* is non-obvious — a hidden constraint, a subtle invariant, a workaround for a specific bug.
+- Don't explain *what* the code does (well-named identifiers do that). Don't reference the current task or PR ("for the X feature"); that belongs in the PR description.
+
+### Adding a slot kind
+
+The two slot kinds (`prompt`, `workspace`) cover almost everything a personal-writing app needs. Resist adding a third unless you've literally typed the same code twice and want to factor it out — every new kind is a new rendering path, a new config schema field, a new settings-form branch.
+
+If you do add one:
+
+1. Extend `SlotConfig` and `validateSlot` in [`homebase/src/lib/config.ts`](homebase/src/lib/config.ts).
+2. Add a generic component in [`homebase/src/components/`](homebase/src/components/).
+3. Wire it into the dispatch in [`homebase/src/routes/morning.tsx`](homebase/src/routes/morning.tsx) and the settings edit form in [`homebase/src/routes/settings.tsx`](homebase/src/routes/settings.tsx).
+4. Document it on the About page.
+
+## Architecture pointers
+
+- **Routes** — [TanStack Router](https://tanstack.com/router) file-based routing in `homebase/src/routes/`.
+- **State** — Zustand stores in `homebase/src/store/`. The morning store owns daily drafts + the user's HomebaseConfig.
+- **Filesystem** — `homebase/src/lib/fs.ts` is the File System Access API wrapper. The picked directory handle is persisted in IndexedDB across reloads.
+- **Config** — `homebase/src/lib/config.ts` is the schema, validator, and disk I/O for `homebase.config.json`. Slot ids are stable; titles/prompts are mutable.
+- **Strategy accordion** — `homebase/src/components/HorizonRow.tsx` and `homebase/src/store/strategy.ts`. Carry-over logic is in `homebase/src/lib/carry-over-resolver.ts`.
+
+## Testing
+
+- Run `pnpm test` before pushing.
+- Add tests for non-trivial logic. Pure functions get unit tests; React components get rendering tests via `@testing-library/react`.
+- The File System Access API and IndexedDB aren't mocked globally; tests that need them mock at the module boundary (see `homebase/src/components/WorkspaceSlot.test.tsx` for the pattern).
+
+## Code of Conduct
+
+Be kind. Don't be a jerk. The full text is in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## Questions
+
+Open a [Discussion](https://github.com/meninoebom/homebase/discussions) for "how does X work" or "would you accept a PR that does Y". Issues are for concrete bugs and features.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Brandon Brown
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,56 @@
-# homebase
+# Homebase
 
-A strategic life guide. Open Homebase to ground yourself in what you've decided matters — life values, life goals, and yearly / monthly / weekly strategic plans — before you open your calendar. The morning writing ritual lives one click away as the **Day** row.
+A personal writing tool. Plain markdown. Your folder. No server.
 
-Everything is plain markdown on your disk. **Your files; your machine; your edits.** There is no backend, no database, no account.
+**[Try it →](https://meninoebom.github.io/homebase/)**
+
+Homebase has two surfaces:
+
+- A **home page** for reflection at long horizons — your values, your goals, the year, the month, the week. Writing at one horizon carries forward to the next when a new period begins, so a fresh week starts with last week's draft instead of a blank page.
+- A **daily page** for whatever you want to write today. Sections (called *slots*) are arranged to suit your practice — morning ritual, evening journal, midday check-in, all the same surface.
+
+Everything you write is plain markdown saved to a folder you choose on your own computer. There is no server, no account, no sync. Open the same files in any text editor; back them up however you back up files.
 
 ## Try it
 
-**Live app:** [https://meninoebom.github.io/homebase/](https://meninoebom.github.io/homebase/)
+Open **[meninoebom.github.io/homebase](https://meninoebom.github.io/homebase/)** in a Chromium browser (Chrome, Edge, Brave, Arc). Homebase uses the browser's File System Access API to read and write your markdown files; Firefox and Safari don't support that yet.
 
-Open it in a Chromium browser (Chrome, Edge, Arc, Brave, Opera). The app needs the browser's File System Access API to read and write your markdown files. Safari and Firefox don't support that API yet.
+On first launch you pick a folder. `~/Documents/homebase-log` works well, but anywhere is fine. You only pick it once.
 
-## Install as a desktop app
+To install as a desktop app, click the install button in the address bar (or the 3-dot menu → "Install Homebase"). The app shell works offline after first load.
 
-Once you're on the live URL in Chromium, click the **install** button in the URL bar (or the 3-dot menu → "Install Homebase"). A standalone window appears, with a desktop icon you can pin to your dock. From then on you launch Homebase like any other app — no browser tab, no dev server.
+## Customize it
 
-Updates roll out automatically the next time you open the app after a new version deploys. Your files are unaffected because they live on your disk, not on a server.
+Most things you'd want to change are configurable from the **Customize** link on the home page or daily page footer:
+
+- Reorder, rename, add, or remove slots on the daily page
+- Edit the prompts and small hint chips
+- Toggle the briefing panel and supply your own quotes
+- Reset to defaults if you want a clean slate
+
+All edits save to a file called `homebase.config.json` in your log folder. You can hand-edit it in any text editor; if you break it, Homebase shows a recovery screen with a "Reset to defaults" button.
+
+The two slot kinds:
+
+- **Prompt slot** — single writing field, optional question above it. Each day starts blank. Examples: Dreams, Inner Weather, Gratitude, Today.
+- **Workspace slot** — a small whiteboard above a writing field. The whiteboard persists across days; the writing field resets daily. Use a workspace when there's standing context you want to see *before* writing today's entry — goals for a project, the book you're reading, the instrument you're practicing.
 
 ## Your data stays on your disk
 
-On first launch, Homebase asks you to pick a folder. The recommended location is `~/Documents/homebase-strategy/` (you can choose anywhere). Your strategic plans live as plain markdown files in that folder, on your machine. Nothing is sent to a server. Nothing is stored in a database.
+The app is a static site hosted on GitHub Pages. There is no backend, no database, no telemetry. Your writing never leaves your machine. The browser's File System Access API lets the app read and write the folder you pick; that access ends when you close the tab.
 
-If you ever want a real backup, the simplest move is `git init` inside your strategy folder and push it to a private repo. Strategic plans are exactly the kind of thing whose history is interesting — diffs over months show how your thinking evolved.
+For a real backup: `git init` inside your log folder and push to a private repo. Diffs over months tell you something interesting about how your thinking shifted.
 
-The morning writing ritual writes to a separate folder (`~/Documents/homebase-log/`) for the same reason: durable plain text, your disk, no service to depend on. **The log file IS the memory; grep is the memory layer.**
+## Contribute
 
-## What's in the app
+Homebase is small and personal, but it's open source ([MIT](LICENSE)) and contributions are welcome. Some ways in:
 
-Six rows in a vertical accordion, top to bottom:
+- **Try it and tell me what's broken.** [Open an issue](https://github.com/meninoebom/homebase/issues/new/choose).
+- **Pick up a [`good first issue`](https://github.com/meninoebom/homebase/labels/good%20first%20issue).**
+- **Translate the default prompts** into another language.
+- **Build something niche** — a slot kind for habits with reps, a calendar overlay, a different briefing source. PRs welcome.
 
-```
-i.    Life values    PERSISTENT
-ii.   Life goals     PERSISTENT
-iii.  Year           2026
-iv.   Month          MAY 2026
-v.    Week           WEEK 18, 2026
-vi.   Day            OPEN MORNING RITUAL  →
-```
-
-Click any of i–v to expand a preview (lead paragraph + numbered items + Open/Edit actions). Click Open to drop into a full-page editor for that horizon. Click Day to launch the morning writing ritual unchanged.
-
-Time-bound rows (year/month/week) carry over from the prior period when you enter a new one — a banner shows "Carried from April 2026 — review and edit, or clear" so the prior thinking is the editable starting point, not a blank page.
-
-## The design
-
-Editorial system inspired by The New Criterion. Cream paper, dusty-red signature accent, italic Newsreader display + Inter Tight chrome. The strategic accordion's source-of-truth design canvas is at `Homebase Redesign/`.
-
-This is a *writing practice that happens to be structured.* Not a life tracker. No streaks, no completion percentages, no scores.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and conventions.
 
 ## Local development
 
@@ -54,45 +59,37 @@ Repo layout:
 ```
 homebase/                      # the app — Vite+ + React + TanStack Router
   src/                         # routes, components, store
-  public/                      # icons, manifest source
+  public/                      # icons, manifest
   vite.config.ts               # Vite + PWA + Tailwind config
-docs/                          # durable design notes (plan, rationale, etc.)
-research/                      # archived prototypes (bash shell spike, etc.)
-Homebase Redesign/             # current design canvas (HTML + CSS + JSX prototype)
+docs/                          # durable design notes
 .github/workflows/             # CI + Pages deploy
-.llm/                          # AI workflow scratch (gitignored)
 ```
 
-Daily commands (run from the repo root — these forward to `homebase/`):
+Daily commands (from the repo root):
 
 ```bash
+pnpm install      # first time only
 pnpm dev          # Vite dev server at http://localhost:47823
-pnpm build        # production build to homebase/dist/
+pnpm test         # vitest run once
+pnpm typecheck    # tsc --noEmit
 pnpm check        # format + lint
 pnpm check:fix    # auto-fix
-pnpm test         # vitest run once
-pnpm test:watch   # vitest watch mode
-pnpm typecheck    # tsc --noEmit
+pnpm build        # production build to homebase/dist/
 ```
 
-The dev server is pinned to **port 47823** (not the Vite default 5173) to dodge collisions with other Vite projects on the same machine; `strictPort: true` makes a collision fail loudly instead of silently picking the next port. Configured in `homebase/vite.config.ts` under `server.port`.
+The dev server is pinned to port 47823 to dodge collisions with other Vite projects (`strictPort: true` fails loudly instead of picking the next port).
 
-Under the hood the toolchain is Vite+ (`vp`), wrapping Vite + Vitest + Oxlint + Oxfmt. See `homebase/AGENTS.md` for the full `vp` reference, and `CLAUDE.md` (root) for project-specific gotchas.
+Under the hood the toolchain is Vite+ (`vp`), wrapping Vite + Vitest + Oxlint + Oxfmt. See [homebase/AGENTS.md](homebase/AGENTS.md) for the full `vp` reference and [CLAUDE.md](CLAUDE.md) for project-specific gotchas.
 
 ## CI / deploy
 
 Two workflows:
 
 - `.github/workflows/ci.yml` — runs on every PR and push to main. Format + lint + typecheck + tests. Required check; gates auto-merge.
-- `.github/workflows/deploy.yml` — runs on push to main. Builds with `BASE_PATH=/homebase/` and publishes to GitHub Pages. The live URL above is the output.
+- `.github/workflows/deploy.yml` — runs on push to main. Builds with `BASE_PATH=/homebase/` and publishes to GitHub Pages.
 
 Branch protection on `main` requires the CI check to pass before merge.
 
-## Pointers
+## License
 
-- **Active plan:** `.llm/active-plan.md` (gitignored — current in-flight work)
-- **Design canvas:** `Homebase Redesign/Homebase.html` (open in a browser; runs the prototype offline)
-- **Morning ritual plan (historical):** `docs/plan-morning-ritual.md`
-- **Five rules:** `docs/plan-morning-ritual.md` §15
-- **Strategic-layer rationale:** `.llm/design-strategic-layer/rationale.md`
-- **Engineering gym** (separate repo): `meninoebom/engineering-gym`
+[MIT](LICENSE) — do whatever you want with it; just keep the copyright notice.


### PR DESCRIPTION
## Summary

The repo was public but had no LICENSE, so technically nobody could legally fork or contribute. This bundle ships the actual open-source onboarding files plus a contributor-friendly README and issue/PR templates.

- **LICENSE** — MIT, copyright Brandon Brown 2026
- **README.md** — rewritten for someone landing from a link, not a developer who already knows the project. New structure: what it is · try it · customize it · your data stays on your disk · contribute · local development
- **CONTRIBUTING.md** — dev setup, conventions (branches, commits, code style, comments), architecture pointers, where to ask questions
- **.github/PULL_REQUEST_TEMPLATE.md** — summary + test plan + screenshots
- **.github/ISSUE_TEMPLATE/bug.md** — bug report scaffold
- **.github/ISSUE_TEMPLATE/feature.md** — feature request scaffold
- **.github/ISSUE_TEMPLATE/config.yml** — disables blank issues, links to Discussions for "how do I" questions

## What's intentionally NOT in this PR

**Code of Conduct.** GitHub provides a one-click Contributor Covenant via Settings → Add file → "Code of Conduct" → choose a template. That's easier than hand-committing the boilerplate, and it'll show up at the standard `/CODE_OF_CONDUCT.md` path the same way.

## To-do for you on GitHub after this lands

These need clicks I can't do from CLI:

1. **Repo About panel** (right side of repo page → click ⚙):
   - Description: "Personal writing tool. Plain markdown, your folder, no server."
   - Website: \`https://meninoebom.github.io/homebase/\`
   - Topics: \`journaling\`, \`writing\`, \`markdown\`, \`personal-tools\`, \`local-first\`, \`react\`, \`pwa\`
2. **Settings → General → Features**: enable **Discussions**
3. **Settings → Add file**: choose **"Code of Conduct"** → pick **Contributor Covenant** → commit
4. **Add a few \`good first issue\`-labeled issues** so newcomers have a way in. Easy candidates: "Add Firefox-not-supported message", "Translate default prompts to \$LANG", "Add tooltip explaining what 'persistent' means in workspace context"
5. (Optional) **social preview image** in Settings → General → Social preview — 1280×640, can just be a screenshot of the home page

## Test plan

- [x] LICENSE renders cleanly on GitHub (it's a standard MIT)
- [x] README renders cleanly with all the links resolving
- [x] Issue templates show up at \`/issues/new/choose\`
- [x] PR template auto-populates this very PR (you're reading it!)
- [x] Discussions link in config.yml works (will once you enable Discussions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)