### PR TITLE
chore(strategy): remove redundant Edit button from SectionPreview

### DIFF
--- a/homebase/src/components/HorizonRow.tsx
+++ b/homebase/src/components/HorizonRow.tsx
@@ -301,12 +301,7 @@ function StrategyRow({ horizon }: { horizon: Exclude<Horizon | "day", "day"> }) 
               </button>
             </>
           ) : (
-            <SectionPreview
-              horizon={horizon}
-              content={row.content}
-              onOpen={openEditor}
-              onEdit={openEditor}
-            />
+            <SectionPreview horizon={horizon} content={row.content} onOpen={openEditor} />
           )}
         </div>
       )}

--- a/homebase/src/components/SectionPreview.tsx
+++ b/homebase/src/components/SectionPreview.tsx
@@ -22,10 +22,9 @@ interface Props {
   horizon: Horizon;
   content: string;
   onOpen: () => void;
-  onEdit: () => void;
 }
 
-export function SectionPreview({ horizon, content, onOpen, onEdit }: Props) {
+export function SectionPreview({ horizon, content, onOpen }: Props) {
   const lead = extractLead(content);
   const items = extractItems(content);
   const isTimeBound = horizon === "year" || horizon === "month" || horizon === "week";
@@ -90,28 +89,19 @@ export function SectionPreview({ horizon, content, onOpen, onEdit }: Props) {
 
       <div className="mt-[22px] flex flex-wrap items-center gap-7">
         <ActionButton label="Open" onClick={onOpen} />
-        <ActionButton label="Edit" onClick={onEdit} quiet />
       </div>
     </div>
   );
 }
 
-function ActionButton({
-  label,
-  onClick,
-  quiet,
-}: {
-  label: string;
-  onClick: () => void;
-  quiet?: boolean;
-}) {
+function ActionButton({ label, onClick }: { label: string; onClick: () => void }) {
   return (
     <button
       type="button"
       onClick={onClick}
       className="cursor-pointer border-0 bg-transparent p-0 py-1 font-sans text-[11px] font-semibold uppercase transition-colors"
       style={{
-        color: quiet ? "var(--ink-3)" : "var(--accent-1)",
+        color: "var(--accent-1)",
         letterSpacing: "0.22em",
         display: "inline-flex",
         alignItems: "center",

--- a/homebase/src/routes/horizon.$id.tsx
+++ b/homebase/src/routes/horizon.$id.tsx
@@ -1,6 +1,6 @@
 // /horizon/:id — full-page editor for one strategic horizon.
 //
-// Reached from the SectionPreview's "Open" or "Edit" actions on the
+// Reached from the SectionPreview's "Open" action on the
 // accordion at /. Re-uses the same StrategyStore, MarkdownEditor,
 // CarryOverBanner, HorizonInvitation, SaveIndicator, and useAutosave
 // hook — the only thing this route adds is the page chrome (back link,


### PR DESCRIPTION
## Summary

Open and Edit on the strategic accordion both navigated to the same \`/horizon/:id\` route — leftover from an earlier two-state design that never landed. Same click, same destination, two buttons. Removed Edit; Open is enough.

- \`SectionPreview\` no longer takes \`onEdit\`
- \`HorizonRow\` stops passing the duplicate handler
- \`ActionButton\`'s \`quiet\` prop dropped (only ever set by the Edit button)
- Stale comment in \`horizon.\$id.tsx\` updated

## Test plan

- [x] \`pnpm test\` (147 passing)
- [x] \`pnpm typecheck\`
- [x] \`pnpm check\`
- [x] \`pnpm build\`
- [ ] Manual: expand a strategic row with content, confirm only "Open" shows; click goes to /horizon/:id

🤖 Generated with [Claude Code](https://claude.com/claude-code)