### PR TITLE
docs: catch up on the single-folder model from PR #68

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,14 +42,17 @@ If you ever need a reactive placeholder, the CodeMirror-idiomatic fix is a `Comp
 
 ### `/about` is whitelisted past `SetupGate`
 
-`SetupGate` (`homebase/src/components/SetupGate.tsx`) wraps the entire `RouterProvider` in `main.tsx`, which means *every* route is gated behind the log-folder picker. `/about` opts out via a path check (`isPublicRoute()`) so a first-time visitor can read what Homebase is before granting filesystem access.
+`SetupGate` (`homebase/src/components/SetupGate.tsx`) wraps the entire `RouterProvider` in `main.tsx`, which means *every* other route is gated behind the homebase-folder picker. `/about` opts out via a path check (`isPublicRoute()`) so a first-time visitor can read what Homebase is before granting filesystem access.
 
-Two things to know:
+The check reads `window.location.pathname` once. SetupGate is rendered outside `RouterProvider`, so client-side nav does *not* re-evaluate it. User-visible bug surface: someone landing on `/about` and then navigating to `/morning` would bypass SetupGate; `/morning` would fail at runtime when it tries to read the folder. If you add another colophon-style public route (privacy, FAQ), extend `isPublicRoute()` — and ideally only allow it as the entry route, not as a navigation target from inside the gated app.
 
-1. **The check reads `window.location.pathname` once.** SetupGate is rendered outside `RouterProvider`, so client-side nav does *not* re-evaluate it. The user-visible bug surface: someone landing on `/about` and then navigating to `/morning` would bypass SetupGate; `/morning` would fail at runtime when it tries to read the log dir.
-2. **The strategy routes (`/`, `/horizon/$id`) are independently safe.** They wrap themselves in `StrategyPermissionGate`, so even if SetupGate is bypassed, accordion content stays gated.
+### One folder, one gate
 
-If you add another colophon-style public route (privacy, FAQ), extend `isPublicRoute()`. If you add a *protected* route that needs the log dir, prefer wrapping it per-route à la `StrategyPermissionGate` rather than depending on the root gate.
+Homebase used to keep two separate directory handles — log (`logDir`) and strategy (`strategyDir`) — gated by two near-identical permission screens (`SetupGate` and the now-deleted `StrategyPermissionGate`). First-time users perceived this as the picker asking twice for the same thing. PR #68 collapsed both into a single root handle (`homebaseRoot`) under one gate. Strategy and log files coexist in the same folder; filenames don't collide (strategy is horizon-prefixed, log is date-named).
+
+There is a one-time IDB migration: `loadPersistedHandle()` in `lib/fs.ts` falls back to the legacy `logDir` key and promotes it to `homebaseRoot` on first read. Don't remove that fallback until enough time has passed that no installed PWA still has only the old key.
+
+If you ever need a *second* directory for genuinely-separate data (e.g. exports), give it its own picker reachable from settings — don't reintroduce a second first-run gate.
 
 ## After Completing Work
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Everything you write is plain markdown saved to a folder you choose on your own 
 
 Open **[homebase.you](https://homebase.you)** in a Chromium browser (Chrome, Edge, Brave, Arc). Homebase uses the browser's File System Access API to read and write your markdown files; Firefox and Safari don't support that yet.
 
-On first launch you pick a folder. `~/Documents/homebase-log` works well, but anywhere is fine. You only pick it once.
+On first launch you pick a folder. `~/Documents/homebase` works well, but anywhere is fine. You only pick it once. Both your home-page horizons and your daily entries live in that one folder.
 
 To install as a desktop app, click the install button in the address bar (or the 3-dot menu → "Install Homebase"). The app shell works offline after first load.
 
@@ -28,7 +28,7 @@ Most things you'd want to change are configurable from the **Customize** link on
 - Toggle the briefing panel and supply your own quotes
 - Reset to defaults if you want a clean slate
 
-All edits save to a file called `homebase.config.json` in your log folder. You can hand-edit it in any text editor; if you break it, Homebase shows a recovery screen with a "Reset to defaults" button.
+All edits save to a file called `homebase.config.json` in your homebase folder. You can hand-edit it in any text editor; if you break it, Homebase shows a recovery screen with a "Reset to defaults" button.
 
 The two slot kinds:
 
@@ -39,7 +39,7 @@ The two slot kinds:
 
 The app is a static site hosted on GitHub Pages. There is no backend, no database, no telemetry. Your writing never leaves your machine. The browser's File System Access API lets the app read and write the folder you pick; that access ends when you close the tab.
 
-For a real backup: `git init` inside your log folder and push to a private repo. Diffs over months tell you something interesting about how your thinking shifted.
+For a real backup: `git init` inside your homebase folder and push to a private repo. Diffs over months tell you something interesting about how your thinking shifted.
 
 ## Contribute
 

--- a/homebase/README.md
+++ b/homebase/README.md
@@ -89,10 +89,12 @@ The dev server is pinned to **port 47823** (`strictPort: true` in `vite.config.t
 
 ## Where data lives
 
-- **`homebase.config.json`** — slots + briefing config, written next to the user's day files. See `lib/config.ts` for schema and validation.
+Everything lives in the single folder the user picks at first run (one directory handle, persisted in IndexedDB under `homebaseRoot`). Filenames don't collide because strategy files are horizon-prefixed and daily files are date-named:
+
+- **`homebase.config.json`** — slots + briefing config. See `lib/config.ts` for schema and validation.
 - **`YYYY-MM-DD.md`** — one file per day, with `## slot-id` sections inside.
 - **`<slot-id>/state.md`** — persistent body for workspace slots.
-- **Strategic horizons** live in a separate folder (a different directory handle, persisted in IndexedDB). `life-values.md`, `life-goals.md`, `year-2026.md`, `month-2026-05.md`, `week-2026-W19.md`.
+- **Strategic horizons** — `life-values.md`, `life-goals.md`, `year-2026.md`, `month-2026-05.md`, `week-2026-W19.md`, in the same folder.
 
 ## Tooling notes
 


### PR DESCRIPTION
## Summary

Brings the docs in line with the single-folder first-run flow shipped in #68:

- **README (root)** — suggest `~/Documents/homebase` instead of `~/Documents/homebase-log`; drop "log folder" wording in favor of "homebase folder" now that the folder holds horizons too.
- **homebase/README** — rewrite the "Where data lives" section: strategic horizons and daily files share one directory handle. Note that filenames don't collide (strategy is horizon-prefixed, log is date-named).
- **CLAUDE.md** — replace the "/about whitelist + StrategyPermissionGate safety net" gotcha with the new "one folder, one gate" reality. Document the legacy-key IDB migration in `lib/fs.ts` so a future engineer knows not to delete it.

Historical docs (`docs/save-architecture.md`, `docs/plan-morning-ritual.md`, `research/`) are intentionally left untouched — they're time-stamped records of earlier architectures.

## Test plan

- [x] grep'd for stale refs in active docs (`README.md`, `homebase/README.md`, `CLAUDE.md`, `homebase/AGENTS.md`) — only intentional historical mentions remain
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)