### PR TITLE
feat(briefing): one-time backfill from curated rotation

### DIFF
--- a/homebase/src/lib/config.test.ts
+++ b/homebase/src/lib/config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   defaultConfig,
   legacyDefaultConfig,
+  migrateLoadedConfig,
   parseConfig,
   serializeConfig,
   validateConfig,
@@ -180,6 +181,64 @@ describe("legacyDefaultConfig", () => {
   it("includes the existing briefing quote so Brandon's setup looks identical post-migration", () => {
     const config = legacyDefaultConfig();
     expect(config.briefing.quotes.length).toBeGreaterThan(0);
+  });
+});
+
+describe("migrateLoadedConfig", () => {
+  function withQuotes(quotes: string[]): HomebaseConfig {
+    return {
+      ...defaultConfig(),
+      briefing: { enabled: true, quotes },
+    };
+  }
+
+  it("backfills the curated rotation when quotes is exactly the legacy Jobs quote", () => {
+    const before = withQuotes(["The only way to do great work is to love what you do."]);
+    const { config, migrated } = migrateLoadedConfig(before);
+    expect(migrated).toBe(true);
+    expect(config.briefing.quotes.length).toBeGreaterThan(1);
+    expect(config.briefing.quotes).not.toContain(
+      "The only way to do great work is to love what you do.",
+    );
+  });
+
+  it("backfills the curated rotation when quotes is empty", () => {
+    const { config, migrated } = migrateLoadedConfig(withQuotes([]));
+    expect(migrated).toBe(true);
+    expect(config.briefing.quotes.length).toBeGreaterThan(1);
+  });
+
+  it("leaves a deliberately curated list untouched", () => {
+    const mine = ["my favorite quote", "another one I picked"];
+    const before = withQuotes(mine);
+    const { config, migrated } = migrateLoadedConfig(before);
+    expect(migrated).toBe(false);
+    expect(config.briefing.quotes).toEqual(mine);
+  });
+
+  it("leaves a list with the legacy quote plus user additions untouched", () => {
+    const mine = ["The only way to do great work is to love what you do.", "one I added"];
+    const { config, migrated } = migrateLoadedConfig(withQuotes(mine));
+    expect(migrated).toBe(false);
+    expect(config.briefing.quotes).toEqual(mine);
+  });
+
+  it("is idempotent — re-running on a migrated config returns migrated:false", () => {
+    const first = migrateLoadedConfig(withQuotes([]));
+    expect(first.migrated).toBe(true);
+    const second = migrateLoadedConfig(first.config);
+    expect(second.migrated).toBe(false);
+    expect(second.config.briefing.quotes).toEqual(first.config.briefing.quotes);
+  });
+
+  it("preserves briefing.enabled and other config fields", () => {
+    const before: HomebaseConfig = {
+      ...withQuotes([]),
+      briefing: { enabled: false, quotes: [] },
+    };
+    const { config } = migrateLoadedConfig(before);
+    expect(config.briefing.enabled).toBe(false);
+    expect(config.slots).toEqual(before.slots);
   });
 });
 

--- a/homebase/src/lib/config.ts
+++ b/homebase/src/lib/config.ts
@@ -176,6 +176,45 @@ export function serializeConfig(config: HomebaseConfig): string {
   return JSON.stringify(config, null, 2) + "\n";
 }
 
+// -- Migrations ---------------------------------------------------------
+
+/**
+ * Legacy seed: the single Steve Jobs quote that pre-curation builds
+ * shipped as the entire briefing rotation. We match against this exact
+ * value so the backfill only touches configs that were never actually
+ * customized by the user.
+ */
+const LEGACY_SINGLE_QUOTE = "The only way to do great work is to love what you do.";
+
+/**
+ * One-time backfill for users who landed before the curated briefing
+ * rotation shipped. Replaces `briefing.quotes` with the default
+ * rotation if and only if the existing list is empty or contains
+ * exactly the legacy single-Jobs-quote — never overwrites a list the
+ * user has deliberately curated.
+ *
+ * Returns `{ config, migrated }` so the caller can persist the result
+ * exactly once. Idempotent: after migration the quotes no longer
+ * match the legacy pattern, so subsequent calls are no-ops.
+ */
+export function migrateLoadedConfig(config: HomebaseConfig): {
+  config: HomebaseConfig;
+  migrated: boolean;
+} {
+  const quotes = config.briefing.quotes;
+  const isLegacyOnly = quotes.length === 1 && quotes[0] === LEGACY_SINGLE_QUOTE;
+  if (quotes.length !== 0 && !isLegacyOnly) {
+    return { config, migrated: false };
+  }
+  return {
+    config: {
+      ...config,
+      briefing: { ...config.briefing, quotes: [...DEFAULT_BRIEFING_QUOTES] },
+    },
+    migrated: true,
+  };
+}
+
 // -- Defaults -----------------------------------------------------------
 
 /**

--- a/homebase/src/store/ritual.ts
+++ b/homebase/src/store/ritual.ts
@@ -13,6 +13,7 @@ import { create } from "zustand";
 import {
   defaultConfig,
   legacyDefaultConfig,
+  migrateLoadedConfig,
   readConfig,
   writeConfig,
   type HomebaseConfig,
@@ -86,7 +87,11 @@ export const useRitualStore = create<RitualState>()((set, get) => ({
       set({ configError: result, loaded: true });
       return;
     } else {
-      config = result.config;
+      const migration = migrateLoadedConfig(result.config);
+      config = migration.config;
+      if (migration.migrated) {
+        await writeConfig(config);
+      }
     }
 
     const sections = await readDaySections(todayISO());


### PR DESCRIPTION
## Summary
Existing users who landed before the curated briefing rotation shipped have either an empty `briefing.quotes` list or the single legacy Jobs quote in their `homebase.config.json`. Code defaults don't retroactively update saved configs, so without this they'd keep seeing the old briefing forever.

`migrateLoadedConfig()` backfills `briefing.quotes` with the curated rotation **if and only if** the existing list is:
- empty, **or**
- exactly the legacy single-Jobs-quote seed.

Any other list — including the legacy quote plus user additions — is left untouched. The migration is hooked into `loadToday()` in the ritual store: runs once on the first load after upgrade, persists via `writeConfig`, and is idempotent thereafter.

## Why this shape
- **Exact-match guard** is what makes it safe. A coarser rule like "backfill if quotes ≤ 1" would silently overwrite someone who deliberately curated a single favorite quote.
- **No version bump.** The schema didn't change, only contents. Versioning is for parser-level migrations; one-time content backfill is just a load-time hook.
- **Idempotent by construction.** After migration the list no longer matches the legacy pattern, so subsequent calls are no-ops.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 153/153 pass (6 new migration tests)
- New tests cover: legacy-seed backfill, empty-list backfill, deliberately-curated list left alone, legacy-plus-additions left alone, idempotency, and that `briefing.enabled` + slots are preserved
- [ ] Open the deployed app once, confirm `homebase.config.json` now contains the curated rotation and the briefing card shows a different quote

🤖 Generated with [Claude Code](https://claude.com/claude-code)