### PR TITLE
feat(strategy): surface carried content in preview + Carried label

### DIFF
--- a/homebase/src/components/HorizonRow.test.tsx
+++ b/homebase/src/components/HorizonRow.test.tsx
@@ -3,8 +3,31 @@
 // what jsdom can verify reliably.
 
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { HorizonRow } from "./HorizonRow";
+import { useStrategyStore, type RowState } from "../store/strategy";
+import type { Horizon } from "../lib/period-key";
+
+// Inject row state for tests that exercise content/carry-over branches.
+// The production store is a singleton — set state directly rather than mock fs.
+function setRowState(horizon: Horizon, patch: Partial<RowState>) {
+  useStrategyStore.setState((s) => ({
+    rows: { ...s.rows, [horizon]: { ...s.rows[horizon], ...patch } },
+  }));
+}
+
+afterEach(() => {
+  for (const h of ["life-values", "life-goals", "year", "month", "week"] as const) {
+    setRowState(h, {
+      expanded: false,
+      content: "",
+      carryOver: null,
+      saveStatus: "idle",
+      dirty: false,
+      loaded: false,
+    });
+  }
+});
 
 describe("HorizonRow", () => {
   it("Day row shows 'Open today's page' and a → arrow", () => {
@@ -53,5 +76,37 @@ describe("HorizonRow", () => {
     render(<HorizonRow horizon="week" />);
     expect(screen.getByText("Week")).toBeInTheDocument();
     expect(screen.getByText(/^Week \d{1,2}, \d{4}$/)).toBeInTheDocument();
+  });
+
+  it("week row with carry-over swaps the header label to 'Carried · Week N' (no year)", () => {
+    setRowState("week", {
+      loaded: true,
+      content: "carried body",
+      carryOver: { content: "carried body", sourcePeriod: "2026-W18" },
+    });
+    render(<HorizonRow horizon="week" />);
+    expect(screen.getByText("Carried")).toBeInTheDocument();
+    // Short label drops the year.
+    expect(screen.getByText(/^Week \d{1,2}$/)).toBeInTheDocument();
+    // The full "Week N, YYYY" form does NOT appear when carried.
+    expect(screen.queryByText(/^Week \d{1,2}, \d{4}$/)).toBeNull();
+  });
+
+  it("expanded week row with carry-over renders the banner AND the preview body", () => {
+    setRowState("week", {
+      expanded: true,
+      loaded: true,
+      content: "Carried preview lead.\n\n- one\n- two",
+      carryOver: { content: "Carried preview lead.\n\n- one\n- two", sourcePeriod: "2026-W18" },
+    });
+    render(<HorizonRow horizon="week" />);
+    // Banner is present (marginalia register)...
+    expect(screen.getByText(/Carried from/)).toBeInTheDocument();
+    // ...and the preview body renders alongside it.
+    expect(screen.getByText("Carried preview lead.")).toBeInTheDocument();
+    expect(screen.getByText("one")).toBeInTheDocument();
+    expect(screen.getByText("two")).toBeInTheDocument();
+    // Open action remains available so the user can drill into the editor.
+    expect(screen.getByText("Open")).toBeInTheDocument();
   });
 });

--- a/homebase/src/components/HorizonRow.tsx
+++ b/homebase/src/components/HorizonRow.tsx
@@ -56,6 +56,19 @@ function metaFor(horizon: Horizon | "day"): string {
   return PeriodKey.format(horizon, key);
 }
 
+/**
+ * Short label for the period (no year), used in the "Carried · ___" form.
+ * Year keeps its 4-digit form; month becomes "May"; week becomes "Week 20".
+ */
+function shortMetaFor(horizon: Exclude<Horizon, "life-values" | "life-goals">): string {
+  const key = PeriodKey.current(horizon);
+  if (!key) return "";
+  const full = PeriodKey.format(horizon, key);
+  if (horizon === "year") return full;
+  if (horizon === "month") return full.split(" ")[0]; // "May 2026" → "May"
+  return full.split(",")[0]; // "Week 20, 2026" → "Week 20"
+}
+
 interface HorizonRowProps {
   horizon: Horizon | "day";
   onDayClick?: () => void;
@@ -222,7 +235,15 @@ function StrategyRow({ horizon }: { horizon: Exclude<Horizon | "day", "day"> }) 
             letterSpacing: "0.2em",
           }}
         >
-          {metaFor(horizon)}
+          {row.carryOver && horizon !== "life-values" && horizon !== "life-goals" ? (
+            <>
+              <span style={{ color: "var(--terracotta, #B8472D)" }}>Carried</span>
+              <span aria-hidden="true"> · </span>
+              {shortMetaFor(horizon)}
+            </>
+          ) : (
+            metaFor(horizon)
+          )}
         </span>
         <span
           aria-hidden="true"
@@ -265,13 +286,14 @@ function StrategyRow({ horizon }: { horizon: Exclude<Horizon | "day", "day"> }) 
           className="pl-[68px] pr-5 pb-8 pt-1"
           style={{ borderBottom: "1px solid var(--paper-edge)" }}
         >
-          {row.carryOver ? (
+          {row.carryOver && (
             <CarryOverBanner
               horizon={horizon}
               sourcePeriod={row.carryOver.sourcePeriod}
               onClear={() => clearCarryOver(horizon)}
             />
-          ) : row.loaded && row.content === "" ? (
+          )}
+          {row.loaded && row.content === "" ? (
             <>
               <HorizonInvitation horizon={horizon} />
               <button


### PR DESCRIPTION
## Summary

- The carry-over banner was a *replacement* for the section preview, hiding the persisted body behind an Open click. Promote it to a header **above** the preview so the carried content (lead + items + Open/Edit actions) is visible the moment the row is expanded — matching the visual register of any other owned section.
- Add a **"Carried · Week N"** header label (terracotta accent on the word "Carried") so even the collapsed row signals provenance before the user expands.
- To support the collapsed-state label, decouple load from expand in the Zustand store: extract `loadIfNeeded` as a shared helper, add a `preloadRow` action, and call it for year/month/week from the accordion route on mount.

## Test plan

- [ ] Refresh `/` with existing carry-over state (e.g. Week 18 → Week 20). Verify the Week row header reads **Carried · Week 20** (collapsed) without expanding.
- [ ] Expand the Week row. Verify the ※ "Carried from Week 18, 2026 — review and edit, or clear" banner appears **and** the lead + items + Open/Edit buttons render below it.
- [ ] Type any edit. Verify the banner dismisses, the header label reverts to "Week 20, 2026", and content saves normally.
- [ ] Click "clear" in the banner. Verify content empties and the row falls back to the empty-state invitation.
- [ ] Year and Month with carry-over behave the same way (header shows **Carried · 2026** / **Carried · May**).
- [ ] No regressions to Life values / Life goals (persistent — no Carried label) or to the Day row portal.
- [x] All 107 unit tests pass (`pnpm test`), including 4 new ones covering `preloadRow`, the Carried label, and the banner + preview render path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)