### PR TITLE
feat(strategy): prefetch carry-over so first load shows the Carried hint

### DIFF
--- a/homebase/src/store/strategy.test.ts
+++ b/homebase/src/store/strategy.test.ts
@@ -53,6 +53,50 @@ describe("StrategyStore", () => {
     expect(row.dirty).toBe(false);
   });
 
+  it("prefetchRow loads file content without expanding the row", async () => {
+    const store = createStrategyStore(createFakeStrategyFs({ "values.md": "v1" }));
+    await store.getState().prefetchRow("life-values");
+    const row = store.getState().rows["life-values"];
+    expect(row.content).toBe("v1");
+    expect(row.loaded).toBe(true);
+    expect(row.expanded).toBe(false);
+    expect(row.dirty).toBe(false);
+  });
+
+  it("prefetchRow on time-bound horizon resolves carry-over so collapsed row can surface it", async () => {
+    const store = createStrategyStore(createFakeStrategyFs({ "month-2020-01.md": "ancient" }));
+    await store.getState().prefetchRow("month");
+    const row = store.getState().rows.month;
+    expect(row.content).toBe("ancient");
+    expect(row.carryOver).toEqual({ content: "ancient", sourcePeriod: "2020-01" });
+    expect(row.loaded).toBe(true);
+    expect(row.expanded).toBe(false);
+    // Matches expandRow semantic: a carried buffer is dirty and will commit
+    // once the user lands on the editor (autosave fires there, not on home).
+    expect(row.dirty).toBe(true);
+  });
+
+  it("prefetchRow on time-bound horizon with no history leaves the row unloaded", async () => {
+    const store = createStrategyStore(createFakeStrategyFs());
+    await store.getState().prefetchRow("year");
+    const row = store.getState().rows.year;
+    expect(row.content).toBe("");
+    expect(row.carryOver).toBeNull();
+    expect(row.loaded).toBe(false);
+  });
+
+  it("expandRow after prefetchRow does not re-fetch (loaded short-circuit)", async () => {
+    const fs = createFakeStrategyFs({ "month-2020-01.md": "ancient" });
+    const store = createStrategyStore(fs);
+    await store.getState().prefetchRow("month");
+    // Mutate the underlying file; if expandRow re-reads, content would change.
+    await fs.write("month-2020-01.md", "newer");
+    await store.getState().expandRow("month");
+    const row = store.getState().rows.month;
+    expect(row.content).toBe("ancient"); // still the prefetched value
+    expect(row.expanded).toBe(true);
+  });
+
   it("expandRow re-expand without changes does not re-fetch (loaded short-circuit)", async () => {
     const fs = createFakeStrategyFs({ "values.md": "v1" });
     const store = createStrategyStore(fs);

--- a/homebase/src/store/strategy.ts
+++ b/homebase/src/store/strategy.ts
@@ -130,19 +130,48 @@ export function createStrategyStore(fs: StrategyFsApi): UseBoundStore<StoreApi<S
       }));
     },
 
-    // Read the file *without* expanding the row, so collapsed rows can
-    // surface a faint preview line. Strictly a file read — never runs the
-    // carry-over resolver, since that's an engagement moment that should
-    // only fire on an explicit expand.
+    // Read the row's state *without* expanding it, so collapsed rows can
+    // surface a faint preview line and the header's "Carried · …" label.
+    // Mirrors expandRow's load path: own file first, then carry-over resolver
+    // for time-bound horizons. Safe to run eagerly on accordion mount — the
+    // autosave hook only mounts on the editor route, so prefetched carry-over
+    // never auto-writes from the homepage alone; materialization still
+    // requires the user navigating into /horizon/:id and either editing or
+    // blurring the editor.
     prefetchRow: async (horizon) => {
       if (get().rows[horizon].loaded) return;
       const file = filenameFor(horizon);
       const existing = await fs.read(file);
-      if (existing === null) return;
+
+      let content = "";
+      let carryOver: CarryOver | null = null;
+      if (existing !== null) {
+        content = existing;
+      } else if (horizon === "year" || horizon === "month" || horizon === "week") {
+        const targetPeriod = PeriodKey.current(horizon);
+        if (targetPeriod) {
+          const co = await CarryOverResolver.resolve(fs, horizon, targetPeriod);
+          if (co) {
+            content = co.content;
+            carryOver = co;
+          }
+        }
+      }
+      if (content === "" && carryOver === null) return;
+
       set((s) => ({
         rows: {
           ...s.rows,
-          [horizon]: { ...s.rows[horizon], content: existing, loaded: true },
+          [horizon]: {
+            ...s.rows[horizon],
+            content,
+            carryOver,
+            loaded: true,
+            // Match expandRow: a carried buffer is a pending write that
+            // commits when the user lands on the editor (autosave fires
+            // on blur / debounce there).
+            dirty: carryOver !== null,
+          },
         },
       }));
     },


### PR DESCRIPTION
## Summary

Follow-up to #73. On first load of `/`, the Week row showed nothing carried — the **Carried · Week N** header label and the faint preview line both only appeared after the user expanded the row at least once. That's because `prefetchRow` deliberately did not run the carry-over resolver (the comment called it an "engagement moment").

Push past that boundary: `prefetchRow` now mirrors `expandRow`'s load path — own file first, then carry-over resolver for time-bound horizons. Safe to do eagerly because `useAutosave` only mounts on `/horizon/:id`, so prefetched carry-over does not auto-write from the homepage; the carried buffer still only materializes when the user lands on the editor and edits or blurs.

## After this change

First paint of `/` for a week with no own content but a prior-week carry-over now shows:

```
v. Week        Carried · Week 20   +
     Figure out if I can do the case management…
```

…without any interaction.

## Test plan

- [ ] On the deployed branch, load `/` with existing carry-over state (Week 18 → Week 20). Verify the Week row shows **Carried · Week 20** in the header and a faint preview line under the title, immediately on first paint.
- [ ] Click to expand. Verify ※ banner + full preview body still render (already shipped in #73).
- [ ] Click "clear" in the banner. Verify the row falls back to the empty-state invitation and the **Carried** label disappears from the header.
- [ ] Type any edit in the editor. Verify the banner dismisses, header reverts to `Week 20, 2026`, and content saves normally.
- [x] Unit tests: 4 new for `prefetchRow` (file-only, carry-over resolve, no-history, expand-after-prefetch short-circuit). All 159 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)