### PR TITLE
fix(strategy): swap + ↔ − toggle (drop 45° rotation that read as ×)

### DIFF
--- a/homebase/src/components/HorizonRow.tsx
+++ b/homebase/src/components/HorizonRow.tsx
@@ -258,17 +258,16 @@ function StrategyRow({ horizon }: { horizon: Exclude<Horizon | "day", "day"> }) 
         </span>
         <span
           aria-hidden="true"
-          className="text-right transition-transform duration-200"
+          className="text-right"
           style={{
             fontFamily: "var(--font-sans-ui)",
             fontSize: "28px",
             fontWeight: 300,
             lineHeight: 1,
             color: row.expanded ? "var(--ink-1)" : "var(--ink-3)",
-            transform: row.expanded ? "rotate(45deg)" : "none",
           }}
         >
-          +
+          {row.expanded ? "−" : "+"}
         </span>
         {collapsedPreview && (
           <span


### PR DESCRIPTION
## Summary
- A rotated `+` is visually indistinguishable from `×` and was reading as a delete/close affordance, not as expand/collapse. Nothing in the TOC is deletable.
- Drop the `rotate(45deg)` and swap the glyph: collapsed `+`, expanded `−`. Boring, legible, no scary X.

## Test plan
- [ ] Open `/`, collapsed rows show `+`.
- [ ] Click a row → glyph swaps to `−`, no rotation.
- [ ] Click again → returns to `+`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)