### PR TITLE
fix: surface strategy read failures instead of rendering an overwriteable empty horizon

### DIFF
--- a/homebase/src/components/HorizonLoadError.test.tsx
+++ b/homebase/src/components/HorizonLoadError.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { HorizonLoadError } from "./HorizonLoadError";
+
+describe("HorizonLoadError", () => {
+  it("renders an alert that warns against overwriting unreadable content", () => {
+    render(<HorizonLoadError />);
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/couldn.t be opened/i);
+    expect(alert).toHaveTextContent(/overwrit/i);
+  });
+
+  it("offers a Try again button when onRetry is provided and fires it", () => {
+    const onRetry = vi.fn();
+    render(<HorizonLoadError onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("omits the button when no onRetry is given", () => {
+    render(<HorizonLoadError />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/homebase/src/components/HorizonLoadError.tsx
+++ b/homebase/src/components/HorizonLoadError.tsx
@@ -1,0 +1,46 @@
+// HorizonLoadError — shown in place of a horizon's content when its file
+// failed to load with a real error (not a missing file, which the fs layer
+// maps to an empty horizon). It replaces the "begin anywhere" invitation so
+// the user is NOT invited to type into what looks like a blank horizon and
+// overwrite content that's merely unreadable right now (#80).
+//
+// Presentational: the row's loadError state lives in the strategy store; this
+// just renders the warning and an optional retry that re-runs the load.
+
+export function HorizonLoadError({ onRetry }: { onRetry?: () => void }) {
+  return (
+    <div
+      role="alert"
+      className="rounded"
+      style={{
+        border: "1px solid var(--accent-1)",
+        background: "var(--paper-2)",
+        padding: "14px 16px",
+      }}
+    >
+      <p
+        className="font-serif"
+        style={{ fontSize: "15px", lineHeight: 1.55, color: "var(--ink-1)" }}
+      >
+        This file couldn’t be opened. Its content may still be on disk — don’t edit here until it
+        loads, or you risk overwriting it. Check that the folder is still connected (Customize →
+        Your folder), then try again.
+      </p>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-3 cursor-pointer border-0 bg-transparent p-0 py-1"
+          style={{
+            fontFamily: "var(--font-sans-ui)",
+            fontSize: "15px",
+            fontWeight: 700,
+            color: "var(--accent-1)",
+          }}
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}

--- a/homebase/src/components/HorizonRow.test.tsx
+++ b/homebase/src/components/HorizonRow.test.tsx
@@ -25,6 +25,7 @@ afterEach(() => {
       saveStatus: "idle",
       dirty: false,
       loaded: false,
+      loadError: false,
     });
   }
 });
@@ -90,6 +91,15 @@ describe("HorizonRow", () => {
     expect(screen.getByText(/^Week \d{1,2}$/)).toBeInTheDocument();
     // The full "Week N, YYYY" form does NOT appear when carried.
     expect(screen.queryByText(/^Week \d{1,2}, \d{4}$/)).toBeNull();
+  });
+
+  it("expanded row with loadError shows the error notice instead of the invitation", () => {
+    setRowState("life-values", { expanded: true, loaded: false, loadError: true, content: "" });
+    render(<HorizonRow horizon="life-values" />);
+    // The overwrite-warning alert is shown...
+    expect(screen.getByRole("alert")).toHaveTextContent(/couldn.t be opened/i);
+    // ...and the empty-horizon "Begin" affordance is NOT (that's the hazard).
+    expect(screen.queryByText("Begin")).toBeNull();
   });
 
   it("expanded week row with carry-over renders the banner AND the preview body", () => {

--- a/homebase/src/components/HorizonRow.tsx
+++ b/homebase/src/components/HorizonRow.tsx
@@ -24,6 +24,7 @@ import { useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { CarryOverBanner } from "./CarryOverBanner";
 import { HorizonInvitation } from "./HorizonInvitation";
+import { HorizonLoadError } from "./HorizonLoadError";
 import { SectionPreview } from "./SectionPreview";
 import { extractCollapsedPreview } from "../lib/markdown-preview";
 import { PeriodKey, type Horizon } from "../lib/period-key";
@@ -174,15 +175,17 @@ function StrategyRow({ horizon }: { horizon: Exclude<Horizon | "day", "day"> }) 
 
   // Pull saved content into state on mount so collapsed rows can show a
   // faint preview line. Skips the carry-over resolver — see prefetchRow.
+  // prefetchRow handles read errors internally (sets row.loadError); the
+  // catch is a defensive backstop for anything unexpected.
   useEffect(() => {
-    prefetchRow(horizon).catch(() => {});
+    prefetchRow(horizon).catch((err) => console.error(err));
   }, [horizon, prefetchRow]);
 
   const onToggle = () => {
     if (row.expanded) {
       collapseRow(horizon);
     } else {
-      expandRow(horizon).catch(() => {});
+      expandRow(horizon).catch((err) => console.error(err));
     }
   };
 
@@ -303,7 +306,11 @@ function StrategyRow({ horizon }: { horizon: Exclude<Horizon | "day", "day"> }) 
               onClear={() => clearCarryOver(horizon)}
             />
           )}
-          {row.loaded && row.content === "" ? (
+          {row.loadError ? (
+            <HorizonLoadError
+              onRetry={() => expandRow(horizon).catch((err) => console.error(err))}
+            />
+          ) : row.loaded && row.content === "" ? (
             <>
               <HorizonInvitation horizon={horizon} />
               <button

--- a/homebase/src/routes/horizon.$id.test.tsx
+++ b/homebase/src/routes/horizon.$id.test.tsx
@@ -1,0 +1,37 @@
+// Editor-route coverage for the #80 overwrite guard. The full HorizonEditorPage
+// owns useParams (needs the router), so we test the exported EditorBody directly
+// and inject row state via the store singleton — the same pattern HorizonRow
+// tests use. This pins the most consequential site: the standalone editor must
+// NOT mount when the row failed to load, or the user could overwrite unreadable
+// content.
+
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { EditorBody } from "./horizon.$id";
+import { useStrategyStore, type RowState } from "../store/strategy";
+
+function setRow(patch: Partial<RowState>) {
+  useStrategyStore.setState((s) => ({
+    rows: { ...s.rows, "life-values": { ...s.rows["life-values"], ...patch } },
+  }));
+}
+
+afterEach(() => {
+  setRow({ expanded: false, content: "", carryOver: null, loaded: false, loadError: false });
+  vi.restoreAllMocks();
+});
+
+describe("EditorBody — loadError guard", () => {
+  it("renders the load-error notice and does NOT mount the editor", () => {
+    // Silence the auto-retry's console.error: with loaded=false the mount
+    // effect re-runs expandRow against the FSA singleton, which throws in jsdom.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    setRow({ loadError: true, loaded: false, content: "" });
+
+    render(<EditorBody horizon="life-values" />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/couldn.t be opened/i);
+    // No editable surface — the overwrite hazard is gone.
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+});

--- a/homebase/src/routes/horizon.$id.tsx
+++ b/homebase/src/routes/horizon.$id.tsx
@@ -15,6 +15,7 @@ import { createFileRoute, useNavigate, useParams } from "@tanstack/react-router"
 import { useEffect } from "react";
 import { CarryOverBanner } from "../components/CarryOverBanner";
 import { HorizonInvitation } from "../components/HorizonInvitation";
+import { HorizonLoadError } from "../components/HorizonLoadError";
 import { MarkdownEditor } from "../components/MarkdownEditor";
 import { SaveIndicator } from "../components/SaveIndicator";
 import { useAutosave } from "../hooks/useAutosave";
@@ -97,7 +98,9 @@ function EditorBody({ horizon }: { horizon: Horizon }) {
   // when loaded.
   useEffect(() => {
     if (!row.loaded) {
-      expandRow(horizon).catch(() => {});
+      // expandRow handles read errors internally (sets row.loadError); the
+      // catch is a defensive backstop for anything unexpected.
+      expandRow(horizon).catch((err) => console.error(err));
     }
   }, [horizon, row.loaded, expandRow]);
 
@@ -141,35 +144,44 @@ function EditorBody({ horizon }: { horizon: Horizon }) {
         />
       </header>
 
-      {row.carryOver ? (
-        <CarryOverBanner
-          horizon={horizon}
-          sourcePeriod={row.carryOver.sourcePeriod}
-          onClear={() => clearCarryOver(horizon)}
-        />
+      {row.loadError ? (
+        // Read failed — render the warning, NOT the editor. Mounting the
+        // editor here would invite the user to type into an empty buffer and
+        // overwrite content that's merely unreadable right now (#80).
+        <HorizonLoadError onRetry={() => expandRow(horizon).catch((err) => console.error(err))} />
       ) : (
-        showInvitation && <HorizonInvitation horizon={horizon} />
-      )}
+        <>
+          {row.carryOver ? (
+            <CarryOverBanner
+              horizon={horizon}
+              sourcePeriod={row.carryOver.sourcePeriod}
+              onClear={() => clearCarryOver(horizon)}
+            />
+          ) : (
+            showInvitation && <HorizonInvitation horizon={horizon} />
+          )}
 
-      {/* No editor placeholder: HorizonInvitation owns the empty state above
-          the editor, and CarryOverBanner provides context post-load. The
-          previous attempt to suppress the placeholder via a `showInvitation`
-          ternary failed because MarkdownEditor's CodeMirror state captures
-          the placeholder on first mount (useEffect with empty deps) — by
-          the time `row.loaded` flipped to true, the placeholder was already
-          baked in and could not be retracted. Dropping it entirely is the
-          cleanest fix. */}
-      <div className="relative max-w-[62ch]">
-        <MarkdownEditor
-          value={row.content}
-          onChange={(v) => setContent(horizon, v)}
-          onSave={flushNow}
-          autoFocus
-        />
-        <span className="absolute -right-2 bottom-0">
-          <SaveIndicator status={row.saveStatus} />
-        </span>
-      </div>
+          {/* No editor placeholder: HorizonInvitation owns the empty state above
+              the editor, and CarryOverBanner provides context post-load. The
+              previous attempt to suppress the placeholder via a `showInvitation`
+              ternary failed because MarkdownEditor's CodeMirror state captures
+              the placeholder on first mount (useEffect with empty deps) — by
+              the time `row.loaded` flipped to true, the placeholder was already
+              baked in and could not be retracted. Dropping it entirely is the
+              cleanest fix. */}
+          <div className="relative max-w-[62ch]">
+            <MarkdownEditor
+              value={row.content}
+              onChange={(v) => setContent(horizon, v)}
+              onSave={flushNow}
+              autoFocus
+            />
+            <span className="absolute -right-2 bottom-0">
+              <SaveIndicator status={row.saveStatus} />
+            </span>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/homebase/src/routes/horizon.$id.tsx
+++ b/homebase/src/routes/horizon.$id.tsx
@@ -85,7 +85,10 @@ function HorizonEditorPage() {
   );
 }
 
-function EditorBody({ horizon }: { horizon: Horizon }) {
+// Exported for testing: lets a test inject row state via useStrategyStore and
+// assert the loadError branch renders the notice instead of the editor,
+// without standing up the router (HorizonEditorPage owns useParams).
+export function EditorBody({ horizon }: { horizon: Horizon }) {
   const row = useStrategyStore((s) => s.rows[horizon]);
   const expandRow = useStrategyStore((s) => s.expandRow);
   const setContent = useStrategyStore((s) => s.setContent);

--- a/homebase/src/store/strategy.test.ts
+++ b/homebase/src/store/strategy.test.ts
@@ -2,7 +2,7 @@
 // fake StrategyFs. We never hit the production singleton in tests because
 // it's bound to FSAccess which doesn't exist in jsdom.
 
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 import { createFakeStrategyFs } from "../lib/strategy-fs";
 import { createStrategyStore } from "./strategy";
 
@@ -18,6 +18,7 @@ describe("StrategyStore", () => {
         saveStatus: "idle",
         dirty: false,
         loaded: false,
+        loadError: false,
       });
     }
   });
@@ -106,6 +107,71 @@ describe("StrategyStore", () => {
     store.getState().collapseRow("life-values");
     await store.getState().expandRow("life-values");
     expect(store.getState().rows["life-values"].content).toBe("v1");
+  });
+
+  it("expandRow surfaces a non-missing read failure as loadError without marking the row loaded", async () => {
+    // A NotFoundError means "file doesn't exist" and the fs layer maps it to
+    // null; any OTHER error (revoked permission, real I/O failure) must NOT be
+    // mistaken for an empty horizon — that's the #80 overwrite hazard.
+    const failingFs = createFakeStrategyFs();
+    failingFs.read = async () => {
+      throw new DOMException("permission revoked", "NotAllowedError");
+    };
+    const store = createStrategyStore(failingFs);
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await store.getState().expandRow("life-values");
+
+    const row = store.getState().rows["life-values"];
+    expect(row.loadError).toBe(true);
+    expect(row.loaded).toBe(false); // not "loaded empty" — there may be content on disk
+    expect(row.expanded).toBe(true); // opened so the error shows in place
+    expect(row.content).toBe(""); // no phantom content the user could overwrite
+    expect(spy).toHaveBeenCalledOnce(); // assert before restore — it resets call history
+    spy.mockRestore();
+  });
+
+  it("prefetchRow surfaces a non-missing read failure as loadError without expanding", async () => {
+    const failingFs = createFakeStrategyFs();
+    failingFs.read = async () => {
+      throw new DOMException("permission revoked", "NotAllowedError");
+    };
+    const store = createStrategyStore(failingFs);
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await store.getState().prefetchRow("year");
+    spy.mockRestore();
+
+    const row = store.getState().rows.year;
+    expect(row.loadError).toBe(true);
+    expect(row.loaded).toBe(false);
+    expect(row.expanded).toBe(false); // prefetch never expands
+  });
+
+  it("expandRow retry clears loadError once the read succeeds", async () => {
+    const fs = createFakeStrategyFs({ "values.md": "courage" });
+    let shouldFail = true;
+    const realRead = fs.read.bind(fs);
+    fs.read = async (name) => {
+      if (shouldFail) throw new DOMException("permission revoked", "NotAllowedError");
+      return realRead(name);
+    };
+    const store = createStrategyStore(fs);
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await store.getState().expandRow("life-values");
+    expect(store.getState().rows["life-values"].loadError).toBe(true);
+
+    // User grants permission / retries: the error path left loaded=false, so a
+    // re-expand re-reads rather than short-circuiting.
+    shouldFail = false;
+    await store.getState().expandRow("life-values");
+    spy.mockRestore();
+
+    const row = store.getState().rows["life-values"];
+    expect(row.loadError).toBe(false);
+    expect(row.loaded).toBe(true);
+    expect(row.content).toBe("courage");
   });
 
   it("setContent updates content, marks dirty, dismisses carry-over banner", async () => {

--- a/homebase/src/store/strategy.ts
+++ b/homebase/src/store/strategy.ts
@@ -1,6 +1,6 @@
 // Zustand store for the strategic accordion.
 //
-// State shape per row: { expanded, content, carryOver, saveStatus, dirty, loaded }.
+// State shape per row: { expanded, content, carryOver, saveStatus, dirty, loaded, loadError }.
 // Six horizons are seeded at idle defaults on initialization; the row's
 // content + carryOver are populated lazily on first expand via expandRow.
 //
@@ -22,6 +22,12 @@ export interface RowState {
   saveStatus: SaveStatus;
   dirty: boolean;
   loaded: boolean;
+  // True when the last load attempt threw a real error (not a missing file).
+  // The fs layer maps a missing file to null/""; anything else (revoked
+  // permission, I/O failure) re-throws and lands here. The UI must show an
+  // error instead of the empty-horizon invitation, or the user could type
+  // over content that's merely unreadable and overwrite it (#80).
+  loadError: boolean;
 }
 
 export interface StrategyState {
@@ -45,6 +51,7 @@ function defaultRow(): RowState {
     saveStatus: "idle",
     dirty: false,
     loaded: false,
+    loadError: false,
   };
 }
 
@@ -93,41 +100,56 @@ export function createStrategyStore(fs: StrategyFsApi): UseBoundStore<StoreApi<S
       // First-time expand: read the file. If it exists, that's the content.
       // If it doesn't exist and the horizon is time-bound, run the resolver
       // to find a carry-over candidate.
-      const file = filenameFor(horizon);
-      const existing = await fs.read(file);
+      try {
+        const file = filenameFor(horizon);
+        const existing = await fs.read(file);
 
-      let content = "";
-      let carryOver: CarryOver | null = null;
-      if (existing !== null) {
-        content = existing;
-      } else if (horizon === "year" || horizon === "month" || horizon === "week") {
-        const targetPeriod = PeriodKey.current(horizon);
-        if (targetPeriod) {
-          const co = await CarryOverResolver.resolve(fs, horizon, targetPeriod);
-          if (co) {
-            content = co.content;
-            carryOver = co;
+        let content = "";
+        let carryOver: CarryOver | null = null;
+        if (existing !== null) {
+          content = existing;
+        } else if (horizon === "year" || horizon === "month" || horizon === "week") {
+          const targetPeriod = PeriodKey.current(horizon);
+          if (targetPeriod) {
+            const co = await CarryOverResolver.resolve(fs, horizon, targetPeriod);
+            if (co) {
+              content = co.content;
+              carryOver = co;
+            }
           }
         }
-      }
 
-      set((s) => ({
-        rows: {
-          ...s.rows,
-          [horizon]: {
-            ...s.rows[horizon],
-            expanded: true,
-            content,
-            carryOver,
-            loaded: true,
-            // Carrying content into a never-saved buffer counts as dirty:
-            // user has unsaved content (the prior period's body) sitting in
-            // a file that doesn't exist yet. First flush writes it and the
-            // banner dismisses naturally on first edit.
-            dirty: carryOver !== null,
+        set((s) => ({
+          rows: {
+            ...s.rows,
+            [horizon]: {
+              ...s.rows[horizon],
+              expanded: true,
+              content,
+              carryOver,
+              loaded: true,
+              loadError: false,
+              // Carrying content into a never-saved buffer counts as dirty:
+              // user has unsaved content (the prior period's body) sitting in
+              // a file that doesn't exist yet. First flush writes it and the
+              // banner dismisses naturally on first edit.
+              dirty: carryOver !== null,
+            },
           },
-        },
-      }));
+        }));
+      } catch (err) {
+        // A real read failure (not a missing file — the fs layer maps that to
+        // null). Expand so the error shows in place, but leave loaded=false so
+        // the UI renders an error instead of an empty horizon, and a retry
+        // re-reads rather than short-circuiting. See #80.
+        console.error(`strategy: failed to load ${horizon}`, err);
+        set((s) => ({
+          rows: {
+            ...s.rows,
+            [horizon]: { ...s.rows[horizon], expanded: true, loaded: false, loadError: true },
+          },
+        }));
+      }
     },
 
     // Read the row's state *without* expanding it, so collapsed rows can
@@ -140,40 +162,52 @@ export function createStrategyStore(fs: StrategyFsApi): UseBoundStore<StoreApi<S
     // blurring the editor.
     prefetchRow: async (horizon) => {
       if (get().rows[horizon].loaded) return;
-      const file = filenameFor(horizon);
-      const existing = await fs.read(file);
+      try {
+        const file = filenameFor(horizon);
+        const existing = await fs.read(file);
 
-      let content = "";
-      let carryOver: CarryOver | null = null;
-      if (existing !== null) {
-        content = existing;
-      } else if (horizon === "year" || horizon === "month" || horizon === "week") {
-        const targetPeriod = PeriodKey.current(horizon);
-        if (targetPeriod) {
-          const co = await CarryOverResolver.resolve(fs, horizon, targetPeriod);
-          if (co) {
-            content = co.content;
-            carryOver = co;
+        let content = "";
+        let carryOver: CarryOver | null = null;
+        if (existing !== null) {
+          content = existing;
+        } else if (horizon === "year" || horizon === "month" || horizon === "week") {
+          const targetPeriod = PeriodKey.current(horizon);
+          if (targetPeriod) {
+            const co = await CarryOverResolver.resolve(fs, horizon, targetPeriod);
+            if (co) {
+              content = co.content;
+              carryOver = co;
+            }
           }
         }
-      }
-      if (content === "" && carryOver === null) return;
+        if (content === "" && carryOver === null) return;
 
-      set((s) => ({
-        rows: {
-          ...s.rows,
-          [horizon]: {
-            ...s.rows[horizon],
-            content,
-            carryOver,
-            loaded: true,
-            // Match expandRow: a carried buffer is a pending write that
-            // commits when the user lands on the editor (autosave fires
-            // on blur / debounce there).
-            dirty: carryOver !== null,
+        set((s) => ({
+          rows: {
+            ...s.rows,
+            [horizon]: {
+              ...s.rows[horizon],
+              content,
+              carryOver,
+              loaded: true,
+              loadError: false,
+              // Match expandRow: a carried buffer is a pending write that
+              // commits when the user lands on the editor (autosave fires
+              // on blur / debounce there).
+              dirty: carryOver !== null,
+            },
           },
-        },
-      }));
+        }));
+      } catch (err) {
+        // Same #80 hazard as expandRow: a real read failure must not pass for
+        // an empty row. Flag it (without expanding — this is the collapsed
+        // prefetch) so a later expand surfaces the error instead of an
+        // overwriteable blank.
+        console.error(`strategy: failed to prefetch ${horizon}`, err);
+        set((s) => ({
+          rows: { ...s.rows, [horizon]: { ...s.rows[horizon], loadError: true } },
+        }));
+      }
     },
 
     collapseRow: (horizon) => {
@@ -212,6 +246,7 @@ export function createStrategyStore(fs: StrategyFsApi): UseBoundStore<StoreApi<S
             carryOver: null,
             dirty: false,
             loaded: false,
+            loadError: false,
           },
         },
       }));

--- a/homebase/src/store/strategy.ts
+++ b/homebase/src/store/strategy.ts
@@ -146,7 +146,16 @@ export function createStrategyStore(fs: StrategyFsApi): UseBoundStore<StoreApi<S
         set((s) => ({
           rows: {
             ...s.rows,
-            [horizon]: { ...s.rows[horizon], expanded: true, loaded: false, loadError: true },
+            // carryOver:null keeps the error state self-consistent — a load
+            // failure must not leave a stale "Carried" banner rendering next
+            // to the error notice.
+            [horizon]: {
+              ...s.rows[horizon],
+              expanded: true,
+              loaded: false,
+              loadError: true,
+              carryOver: null,
+            },
           },
         }));
       }
@@ -205,7 +214,7 @@ export function createStrategyStore(fs: StrategyFsApi): UseBoundStore<StoreApi<S
         // overwriteable blank.
         console.error(`strategy: failed to prefetch ${horizon}`, err);
         set((s) => ({
-          rows: { ...s.rows, [horizon]: { ...s.rows[horizon], loadError: true } },
+          rows: { ...s.rows, [horizon]: { ...s.rows[horizon], loadError: true, carryOver: null } },
         }));
       }
     },

--- a/homebase/vite.config.ts
+++ b/homebase/vite.config.ts
@@ -36,6 +36,9 @@ export default defineConfig({
       autoCodeSplitting: true,
       routesDirectory: "./src/routes",
       generatedRouteTree: "./src/routeTree.gen.ts",
+      // Colocated *.test.tsx files next to route modules aren't routes; without
+      // this the plugin warns "does not export a Route" on every build/check.
+      routeFileIgnorePattern: "\\.test\\.",
     }),
     react(),
     tailwindcss(),


### PR DESCRIPTION
Closes #80.

## Problem
When a strategy horizon's file failed to read with a *real* error (revoked permission, I/O failure — not a missing file), the row rendered as an empty horizon ("begin anywhere" invitation / blank editor). A user could type into it and autosave would **overwrite content that was merely unreadable**. Silent data loss masquerading as an empty horizon. (Pre-existing; surfaced by the #79 review.)

## Fix
Mirror the write path's `saveStatus: "error"` pattern with a per-row **`loadError`** state.

- **Store** (`store/strategy.ts`): `expandRow` and `prefetchRow` (both had the bug) now wrap their read path. A missing file still maps to null/empty as before; a real failure sets `row.loadError` (without marking the row `loaded`, so a retry re-reads) and logs to console. `clearCarryOver` resets it.
- **UI**: when `row.loadError`, render a new `HorizonLoadError` notice **instead of** the invitation (`HorizonRow`) and **instead of the editor entirely** (`horizon/$id`) — so the editor never mounts over unreadable content. The notice offers "Try again" (re-runs the load) and points the user at Customize → Your folder.
- Both call sites' `.catch(() => {})` replaced with `console.error` backstops.

The `NotFoundError → null` mapping in the fs layer is unchanged — a missing file is still a legitimate empty horizon.

## Changes
- `store/strategy.ts` — `loadError` on `RowState`; try/catch in `expandRow` + `prefetchRow`; reset in `clearCarryOver`
- `components/HorizonLoadError.tsx` — new presentational notice
- `components/HorizonRow.tsx`, `routes/horizon.$id.tsx` — render the notice on `loadError`; fix swallowing catches

## Tested
- Store: read failure → `loadError` set, `loaded` stays false, no phantom content; prefetch failure flagged without expanding; retry clears `loadError` on success; missing-file behavior unchanged
- `HorizonLoadError`: renders the overwrite warning; Try-again fires; button omitted without `onRetry`
- `HorizonRow`: expanded row with `loadError` shows the notice and **not** the "Begin" affordance
- Full suite: 171 pass; `tsc` + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)