### PR TITLE
fix: surface folder-access failures (config read/write) instead of hanging the day page

### DIFF
--- a/homebase/src/components/FolderAccessError.test.tsx
+++ b/homebase/src/components/FolderAccessError.test.tsx
@@ -1,0 +1,15 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { FolderAccessError } from "./FolderAccessError";
+
+describe("FolderAccessError", () => {
+  it("explains the folder is unreachable, reassures data is safe, and offers retry", () => {
+    const onRetry = vi.fn();
+    render(<FolderAccessError onRetry={onRetry} />);
+    expect(screen.getByText(/can.t reach your folder/i)).toBeInTheDocument();
+    expect(screen.getByText(/safe on disk/i)).toBeInTheDocument();
+    expect(screen.getByText(/reconnect the folder/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/homebase/src/components/FolderAccessError.tsx
+++ b/homebase/src/components/FolderAccessError.tsx
@@ -1,0 +1,37 @@
+// FolderAccessError — full-page recovery screen shown when Homebase can't reach
+// the workspace folder at all (a real fs error reading/writing the config:
+// revoked permission, folder moved or deleted). Distinct from
+// ConfigRecoveryScreen (the config file's contents are bad → Reset) because the
+// recovery here is to RECONNECT the folder, not rewrite the config. Rendered by
+// /day on accessError, so loadToday can't hang the page silently (#85).
+
+const DAY_SANS =
+  "'Inter Tight', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, sans-serif";
+
+export function FolderAccessError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <main className="min-h-screen bg-white" style={{ fontFamily: DAY_SANS }}>
+      <div className="mx-auto max-w-[640px] px-8 pt-12 pb-12">
+        <h1
+          className="mb-4"
+          style={{ fontSize: "28px", fontWeight: 600, letterSpacing: "-0.02em", color: "#111" }}
+        >
+          Homebase can’t reach your folder
+        </h1>
+        <p style={{ fontSize: "17px", lineHeight: 1.55, color: "#374151", margin: "0 0 16px" }}>
+          Your homebase folder may have been moved, deleted, or had its permission revoked. Your
+          writing is safe on disk — Homebase just can’t read or write it right now. Reconnect the
+          folder from <strong>Customize → Your folder</strong>, then try again.
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="cursor-pointer rounded bg-[#111] px-5 py-2.5 text-white hover:bg-[#374151]"
+          style={{ fontFamily: DAY_SANS, fontSize: "15px", fontWeight: 600 }}
+        >
+          Try again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/homebase/src/routes/day.tsx
+++ b/homebase/src/routes/day.tsx
@@ -47,11 +47,9 @@ function DayPage() {
   const accessError = useRitualStore((s) => s.accessError);
 
   useEffect(() => {
-    // loadToday surfaces the day-file read error (draftsError) and config
-    // parse/schema errors (configError) internally, so those don't reject.
-    // NOTE: the config read + first-run write path inside loadToday is still
-    // unguarded — a permission/IO failure there rejects and is dropped by
-    // `void`, hanging the page with no recovery screen. Tracked in #85.
+    // loadToday surfaces every read/write failure internally — config content
+    // (configError), day-file read (draftsError), and folder access
+    // (accessError) — and never rejects, so `void` is safe here.
     void loadToday();
   }, [loadToday]);
 

--- a/homebase/src/routes/day.tsx
+++ b/homebase/src/routes/day.tsx
@@ -15,6 +15,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import { DayLoadError } from "../components/DayLoadError";
+import { FolderAccessError } from "../components/FolderAccessError";
 import { PromptSlot } from "../components/PromptSlot";
 import { WorkspaceSlot } from "../components/WorkspaceSlot";
 import { useRitualStore } from "../store/ritual";
@@ -43,6 +44,7 @@ function DayPage() {
   const config = useRitualStore((s) => s.config);
   const configError = useRitualStore((s) => s.configError);
   const draftsError = useRitualStore((s) => s.draftsError);
+  const accessError = useRitualStore((s) => s.accessError);
 
   useEffect(() => {
     // loadToday surfaces the day-file read error (draftsError) and config
@@ -55,14 +57,21 @@ function DayPage() {
 
   // Auto-save 800ms after any draft change. Gated on `loaded` so we don't
   // race-write an empty file before the disk read settles, and on
-  // `!draftsError` so we never write over a day file that failed to load.
+  // `!draftsError` / `!accessError` so we never write over a day file that
+  // failed to load or into a folder we can't reach.
   useEffect(() => {
-    if (!loaded || !config || draftsError) return;
+    if (!loaded || !config || draftsError || accessError) return;
     const timer = setTimeout(() => {
       void saveNow();
     }, 800);
     return () => clearTimeout(timer);
-  }, [drafts, saveNow, loaded, config, draftsError]);
+  }, [drafts, saveNow, loaded, config, draftsError, accessError]);
+
+  // Folder unreachable is the most fundamental failure (config + drafts both
+  // depend on it), so check it before the content-level recovery screens.
+  if (accessError) {
+    return <FolderAccessError onRetry={() => void loadToday()} />;
+  }
 
   if (configError) {
     return <ConfigRecoveryScreen error={configError} onReset={() => void resetToDefaults()} />;

--- a/homebase/src/store/ritual.test.ts
+++ b/homebase/src/store/ritual.test.ts
@@ -44,6 +44,7 @@ beforeEach(() => {
     config: null,
     configError: null,
     draftsError: false,
+    accessError: false,
     loaded: false,
     saving: false,
     lastSavedAt: null,
@@ -183,7 +184,70 @@ describe("loadToday — error handling", () => {
   });
 });
 
+describe("loadToday — folder access errors", () => {
+  it("surfaces a config-read access failure as accessError instead of hanging", async () => {
+    // readConfig rejects (revoked permission / folder gone) — NOT a missing
+    // file (that's readConfig → { kind: "missing" }). Must not reject out of
+    // loadToday, where day.tsx's `void loadToday()` would drop it.
+    mockReadConfig = () => Promise.reject(new DOMException("permission revoked", "NotAllowedError"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(useRitualStore.getState().loadToday()).resolves.toBeUndefined();
+
+    const state = useRitualStore.getState();
+    expect(state.accessError).toBe(true);
+    expect(state.loaded).toBe(true); // page renders recovery, doesn't hang
+    expect(state.configError).toBeNull();
+    expect(spy).toHaveBeenCalledOnce();
+    spy.mockRestore();
+  });
+
+  it("surfaces a first-run config write failure as accessError", async () => {
+    mockReadConfig = () => Promise.resolve({ kind: "missing" });
+    mockListFiles = () => Promise.resolve([]);
+    mockWriteConfig = () => Promise.reject(new DOMException("denied", "NotAllowedError"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(useRitualStore.getState().loadToday()).resolves.toBeUndefined();
+
+    expect(useRitualStore.getState().accessError).toBe(true);
+    expect(useRitualStore.getState().loaded).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("clears accessError once a later load succeeds", async () => {
+    let shouldFail = true;
+    mockReadConfig = () =>
+      shouldFail
+        ? Promise.reject(new DOMException("denied", "NotAllowedError"))
+        : Promise.resolve({ kind: "ok", config: defaultConfig() });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await useRitualStore.getState().loadToday();
+    expect(useRitualStore.getState().accessError).toBe(true);
+
+    shouldFail = false;
+    await useRitualStore.getState().loadToday();
+    spy.mockRestore();
+
+    expect(useRitualStore.getState().accessError).toBe(false);
+    expect(useRitualStore.getState().config).toEqual(defaultConfig());
+  });
+});
+
 describe("resetToDefaults", () => {
+  it("surfaces accessError when the write fails instead of silently no-op'ing", async () => {
+    useRitualStore.setState({ configError: { kind: "parse-error", message: "x" }, loaded: true });
+    mockWriteConfig = () => Promise.reject(new DOMException("denied", "NotAllowedError"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Must not reject — day.tsx calls `() => void resetToDefaults()`.
+    await expect(useRitualStore.getState().resetToDefaults()).resolves.toBeUndefined();
+
+    expect(useRitualStore.getState().accessError).toBe(true);
+    spy.mockRestore();
+  });
+
   it("writes defaultConfig() and clears configError", async () => {
     useRitualStore.setState({
       configError: { kind: "parse-error", message: "broken" },

--- a/homebase/src/store/ritual.test.ts
+++ b/homebase/src/store/ritual.test.ts
@@ -143,11 +143,12 @@ describe("loadToday — error handling", () => {
   });
 
   it("surfaces a day-file read failure as draftsError without hanging or losing content", async () => {
-    // Config loads fine; the DAY file read fails with a real error (revoked
-    // permission / I/O — not a missing file, which readDaySections maps to {}).
+    // Config loads fine; the DAY file itself is unreadable (e.g. an I/O error,
+    // NOT a missing file → {} and NOT a permission error → accessError). This
+    // is the "this specific file is broken" case that draftsError owns.
     mockReadConfig = () => Promise.resolve({ kind: "ok", config: defaultConfig() });
     mockReadDaySections = () =>
-      Promise.reject(new DOMException("permission revoked", "NotAllowedError"));
+      Promise.reject(new DOMException("disk read failed", "NotReadableError"));
 
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     // Must NOT reject — day.tsx calls `void loadToday()`; an internal reject
@@ -167,7 +168,7 @@ describe("loadToday — error handling", () => {
     let shouldFail = true;
     mockReadDaySections = () =>
       shouldFail
-        ? Promise.reject(new DOMException("permission revoked", "NotAllowedError"))
+        ? Promise.reject(new DOMException("disk read failed", "NotReadableError"))
         : Promise.resolve({ intro: "today's words" });
 
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -181,6 +182,24 @@ describe("loadToday — error handling", () => {
     const state = useRitualStore.getState();
     expect(state.draftsError).toBe(false);
     expect(state.drafts).toEqual({ intro: "today's words" });
+  });
+
+  it("routes a permission failure during the day read to accessError, not draftsError", async () => {
+    // Permission revoked after the config read succeeded but before the day
+    // read — the folder is unreachable, so the user needs the reconnect screen,
+    // not "today's writing couldn't be opened".
+    mockReadConfig = () => Promise.resolve({ kind: "ok", config: defaultConfig() });
+    mockReadDaySections = () =>
+      Promise.reject(new DOMException("permission revoked", "NotAllowedError"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await useRitualStore.getState().loadToday();
+    spy.mockRestore();
+
+    const state = useRitualStore.getState();
+    expect(state.accessError).toBe(true);
+    expect(state.draftsError).toBe(false);
+    expect(state.loaded).toBe(true);
   });
 });
 
@@ -213,6 +232,24 @@ describe("loadToday — folder access errors", () => {
 
     expect(useRitualStore.getState().accessError).toBe(true);
     expect(useRitualStore.getState().loaded).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("surfaces a migration write failure as accessError", async () => {
+    // Existing config that needs migrating (empty quotes triggers migrated:true),
+    // so loadToday takes the migration-write branch — which can also hit a dead
+    // folder.
+    mockReadConfig = () =>
+      Promise.resolve({
+        kind: "ok",
+        config: { ...defaultConfig(), briefing: { enabled: true, quotes: [] } },
+      });
+    mockWriteConfig = () => Promise.reject(new DOMException("denied", "NotAllowedError"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(useRitualStore.getState().loadToday()).resolves.toBeUndefined();
+
+    expect(useRitualStore.getState().accessError).toBe(true);
     spy.mockRestore();
   });
 

--- a/homebase/src/store/ritual.test.ts
+++ b/homebase/src/store/ritual.test.ts
@@ -189,7 +189,8 @@ describe("loadToday — folder access errors", () => {
     // readConfig rejects (revoked permission / folder gone) — NOT a missing
     // file (that's readConfig → { kind: "missing" }). Must not reject out of
     // loadToday, where day.tsx's `void loadToday()` would drop it.
-    mockReadConfig = () => Promise.reject(new DOMException("permission revoked", "NotAllowedError"));
+    mockReadConfig = () =>
+      Promise.reject(new DOMException("permission revoked", "NotAllowedError"));
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(useRitualStore.getState().loadToday()).resolves.toBeUndefined();

--- a/homebase/src/store/ritual.ts
+++ b/homebase/src/store/ritual.ts
@@ -65,6 +65,19 @@ interface RitualState {
 const DAY_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}\.md$/;
 
 /**
+ * True for a "folder unreachable" error (revoked permission), as opposed to a
+ * missing file or a content problem. Such an error means the user must
+ * reconnect the folder, so it routes to accessError no matter which read/write
+ * surfaced it — including a day-file read that fails after the config read
+ * already succeeded.
+ */
+function isAccessError(err: unknown): boolean {
+  return (
+    err instanceof DOMException && (err.name === "NotAllowedError" || err.name === "SecurityError")
+  );
+}
+
+/**
  * Decide which default config to seed when the user has no
  * homebase.config.json yet. If the log dir already has day files, the
  * user is mid-flow on a pre-config build (Brandon, anyone migrating)
@@ -118,6 +131,17 @@ export const useRitualStore = create<RitualState>()((set, get) => ({
       try {
         sections = await readDaySections(todayISO());
       } catch (err) {
+        // A revoked-permission / folder-gone error here means the whole folder
+        // is unreachable (it just happened to surface on the day read after the
+        // config read succeeded) — route it to accessError so the user gets the
+        // "reconnect your folder" screen, not "today's writing" (#85 review).
+        // Any other read failure (e.g. the day file itself is unreadable) stays
+        // draftsError.
+        if (isAccessError(err)) {
+          console.error("ritual: folder unreachable while reading today's day file", err);
+          set({ configError: null, draftsError: false, accessError: true, loaded: true });
+          return;
+        }
         console.error("ritual: failed to read today's day file", err);
         set({
           config,

--- a/homebase/src/store/ritual.ts
+++ b/homebase/src/store/ritual.ts
@@ -37,6 +37,13 @@ interface RitualState {
   // user could write into a blank-looking day and overwrite content that's
   // merely unreadable right now (#83, sibling of #80).
   draftsError: boolean;
+  // True when the workspace folder itself can't be reached — a real fs error
+  // (revoked permission, folder moved/deleted) on the config read or any
+  // config write. Distinct from configError (the file's *contents* are bad,
+  // recover by Reset) because the recovery here is to *reconnect the folder*,
+  // not rewrite the config. Keeps loadToday from rejecting into day.tsx's
+  // `void loadToday()` and hanging the page (#85).
+  accessError: boolean;
   loaded: boolean;
   saving: boolean;
   lastSavedAt: number | null;
@@ -75,45 +82,69 @@ export const useRitualStore = create<RitualState>()((set, get) => ({
   config: null,
   configError: null,
   draftsError: false,
+  accessError: false,
   loaded: false,
   saving: false,
   lastSavedAt: null,
 
   loadToday: async () => {
-    // Read config first. Three paths:
-    //   - missing → seed a default and use it
-    //   - parse-error / schema-error → surface as configError; skip drafts
-    //     load (the morning page renders the recovery screen instead)
-    //   - ok → use it
-    let config: HomebaseConfig;
-    const result = await readConfig();
-    if (result.kind === "missing") {
-      config = await pickFirstRunConfig();
-      await writeConfig(config);
-    } else if (result.kind === "parse-error" || result.kind === "schema-error") {
-      set({ configError: result, draftsError: false, loaded: true });
-      return;
-    } else {
-      const migration = migrateLoadedConfig(result.config);
-      config = migration.config;
-      if (migration.migrated) {
-        await writeConfig(config);
-      }
-    }
-
-    // A real day-file read error (not a missing file — readDaySections maps
-    // that to {}) must not pass for an empty day. Surface it as draftsError so
-    // the page renders a recovery screen instead of editable, overwriteable
-    // fields; loaded stays true so the page doesn't hang, and a retry re-reads.
-    let sections: Record<SlotId, string>;
     try {
-      sections = await readDaySections(todayISO());
+      // Read config first. Three paths:
+      //   - missing → seed a default and use it
+      //   - parse-error / schema-error → surface as configError; skip drafts
+      //     load (the morning page renders the recovery screen instead)
+      //   - ok → use it
+      let config: HomebaseConfig;
+      const result = await readConfig();
+      if (result.kind === "missing") {
+        config = await pickFirstRunConfig();
+        await writeConfig(config);
+      } else if (result.kind === "parse-error" || result.kind === "schema-error") {
+        set({ configError: result, draftsError: false, accessError: false, loaded: true });
+        return;
+      } else {
+        const migration = migrateLoadedConfig(result.config);
+        config = migration.config;
+        if (migration.migrated) {
+          await writeConfig(config);
+        }
+      }
+
+      // A real day-file read error (not a missing file — readDaySections maps
+      // that to {}) must not pass for an empty day. Surface it as draftsError so
+      // the page renders a recovery screen instead of editable, overwriteable
+      // fields; loaded stays true so the page doesn't hang, and a retry re-reads.
+      let sections: Record<SlotId, string>;
+      try {
+        sections = await readDaySections(todayISO());
+      } catch (err) {
+        console.error("ritual: failed to read today's day file", err);
+        set({
+          config,
+          configError: null,
+          draftsError: true,
+          accessError: false,
+          drafts: {},
+          loaded: true,
+        });
+        return;
+      }
+      set({
+        config,
+        configError: null,
+        draftsError: false,
+        accessError: false,
+        drafts: sections,
+        loaded: true,
+      });
     } catch (err) {
-      console.error("ritual: failed to read today's day file", err);
-      set({ config, configError: null, draftsError: true, drafts: {}, loaded: true });
-      return;
+      // A real fs failure on the config read / first-run seed write / migration
+      // write path (revoked permission, folder moved or deleted). Without this
+      // the rejection escapes into day.tsx's `void loadToday()` and the page
+      // hangs unloaded with no recovery. Surface it as accessError instead (#85).
+      console.error("ritual: failed to load homebase config", err);
+      set({ accessError: true, configError: null, draftsError: false, loaded: true });
     }
-    set({ config, configError: null, draftsError: false, drafts: sections, loaded: true });
   },
 
   setDraft: (slotId, body) => {
@@ -152,7 +183,15 @@ export const useRitualStore = create<RitualState>()((set, get) => ({
     // neutral default. Day-file content is left alone. After write,
     // re-run loadToday so the page picks up the new config.
     const fresh = defaultConfig();
-    await writeConfig(fresh);
+    try {
+      await writeConfig(fresh);
+    } catch (err) {
+      // The folder became unreachable — don't let the recovery button silently
+      // no-op (it's invoked via `void resetToDefaults()`). Surface accessError.
+      console.error("ritual: failed to write config on reset", err);
+      set({ accessError: true, configError: null, loaded: true });
+      return;
+    }
     set({ configError: null });
     await get().loadToday();
   },


### PR DESCRIPTION
Closes #85. The last unguarded path in the #80→#83→#85 chain.

## Problem
After #83 guarded the day-file *read*, `loadToday`'s **config read + first-run seed write + migration write** were still unguarded, and `resetToDefaults`' write too. A real fs error there (revoked permission, folder moved/deleted) rejected into `day.tsx`'s `void loadToday()` / `void resetToDefaults()` — hanging the page unloaded with no recovery, and making the config-recovery "Reset" button silently no-op.

## Fix
- **Store** (`store/ritual.ts`): new `accessError` state, **distinct from `configError`**. `loadToday` wraps the config/seed/write path; a real fs failure sets `accessError` (loaded:true) instead of rejecting. `resetToDefaults` guards its write the same way. All success/other-error paths reset `accessError`.
- **Why a separate state:** `configError`'s recovery is *Reset to defaults* (rewrite the file) — wrong for an access failure, where the write itself fails and the fix is to *reconnect the folder*. So `accessError` gets its own recovery screen.
- **UI** (`routes/day.tsx`): renders the new `FolderAccessError` screen on `accessError`, checked **before** configError/draftsError (folder access is the most fundamental dependency). Autosave gated on `!accessError`. `loadToday` no longer rejects, so `void loadToday()` is finally safe across all paths.
- **`components/FolderAccessError.tsx`**: recovery screen — "Homebase can't reach your folder… your writing is safe on disk… reconnect from Customize → Your folder", with Try again.

## Tested
- Store: config-read access failure → `accessError`, `loaded:true`, `loadToday` resolves (no unhandled rejection); first-run write failure → `accessError`; `resetToDefaults` write failure → `accessError` (no silent no-op); `accessError` clears on a later successful load
- `FolderAccessError`: renders the message + Try-again fires
- Full suite: 180 pass; `tsc` + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)