### PR TITLE
fix: surface day-page autosave failures instead of a silent, misleading "saved"

### DIFF
--- a/homebase/src/routes/day.test.tsx
+++ b/homebase/src/routes/day.test.tsx
@@ -1,0 +1,23 @@
+// Footer status-text logic for the day page. The route component itself isn't
+// rendered (router convention); saveFooterText is the pure, exported seam.
+
+import { describe, expect, it } from "vite-plus/test";
+import { saveFooterText } from "./day";
+
+describe("saveFooterText", () => {
+  it("shows 'saving…' while a save is in flight", () => {
+    expect(saveFooterText(true, false, "saved 9:14 am")).toBe("saving…");
+  });
+
+  it("shows an error instead of a stale 'saved' label when the save failed", () => {
+    expect(saveFooterText(false, true, "saved 9:14 am")).toMatch(/couldn.t save/i);
+  });
+
+  it("shows the saved label when idle and healthy", () => {
+    expect(saveFooterText(false, false, "saved 9:14 am")).toBe("saved 9:14 am");
+  });
+
+  it("'saving…' takes precedence over a prior error during a retry", () => {
+    expect(saveFooterText(true, true, "")).toBe("saving…");
+  });
+});

--- a/homebase/src/routes/day.tsx
+++ b/homebase/src/routes/day.tsx
@@ -31,6 +31,16 @@ export const Route = createFileRoute("/day")({
   component: DayPage,
 });
 
+/**
+ * Footer status text. A failed autosave must not keep showing the stale
+ * "saved …" label — surface the failure instead. Pure + exported for testing.
+ */
+export function saveFooterText(saving: boolean, saveError: boolean, savedLabel: string): string {
+  if (saving) return "saving…";
+  if (saveError) return "couldn’t save — check your folder";
+  return savedLabel;
+}
+
 function DayPage() {
   const navigate = useNavigate();
   const loadToday = useRitualStore((s) => s.loadToday);
@@ -38,6 +48,7 @@ function DayPage() {
   const saveNow = useRitualStore((s) => s.saveNow);
   const resetToDefaults = useRitualStore((s) => s.resetToDefaults);
   const saving = useRitualStore((s) => s.saving);
+  const saveError = useRitualStore((s) => s.saveError);
   const lastSavedAt = useRitualStore((s) => s.lastSavedAt);
   const drafts = useRitualStore((s) => s.drafts);
   const loaded = useRitualStore((s) => s.loaded);
@@ -166,8 +177,14 @@ function DayPage() {
         >
           Customize
         </button>
-        <span style={{ fontSize: "13px", fontWeight: 500, color: "#9CA3AF" }}>
-          {saving ? "saving…" : savedLabel}
+        <span
+          style={{
+            fontSize: "13px",
+            fontWeight: 500,
+            color: !saving && saveError ? "#B91C1C" : "#9CA3AF",
+          }}
+        >
+          {saveFooterText(saving, saveError, savedLabel)}
         </span>
       </footer>
     </main>

--- a/homebase/src/store/ritual.test.ts
+++ b/homebase/src/store/ritual.test.ts
@@ -9,6 +9,7 @@ let mockReadConfig: () => Promise<ReadConfigResult>;
 let mockWriteConfig: (config: HomebaseConfig) => Promise<void>;
 let mockListFiles: () => Promise<string[]>;
 let mockReadDaySections: () => Promise<Record<string, string>>;
+let mockSaveDay: () => Promise<void>;
 
 vi.mock("../lib/config", async () => {
   const actual = await vi.importActual<typeof import("../lib/config")>("../lib/config");
@@ -25,7 +26,7 @@ vi.mock("../lib/fs", () => ({
 
 vi.mock("../lib/log", () => ({
   readDaySections: () => mockReadDaySections(),
-  saveDay: () => Promise.resolve(),
+  saveDay: () => mockSaveDay(),
   todayISO: () => "2026-05-08",
 }));
 
@@ -38,6 +39,7 @@ beforeEach(() => {
   mockWriteConfig = () => Promise.resolve();
   mockListFiles = () => Promise.resolve([]);
   mockReadDaySections = () => Promise.resolve({});
+  mockSaveDay = () => Promise.resolve();
   // Reset singleton state between tests.
   useRitualStore.setState({
     drafts: {},
@@ -47,6 +49,7 @@ beforeEach(() => {
     accessError: false,
     loaded: false,
     saving: false,
+    saveError: false,
     lastSavedAt: null,
   });
 });
@@ -314,5 +317,41 @@ describe("resetToDefaults", () => {
     expect(writes.length).toBeGreaterThanOrEqual(1);
     expect(writes[0]).toEqual(defaultConfig());
     expect(useRitualStore.getState().configError).toBeNull();
+  });
+});
+
+describe("saveNow — autosave failures", () => {
+  it("surfaces a write failure as saveError without throwing or dropping the draft", async () => {
+    mockSaveDay = () => Promise.reject(new DOMException("denied", "NotAllowedError"));
+    useRitualStore.getState().setDraft("intro", "morning words");
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // day.tsx fires `void saveNow()` — it must not reject.
+    await expect(useRitualStore.getState().saveNow()).resolves.toBeUndefined();
+
+    const state = useRitualStore.getState();
+    expect(state.saveError).toBe(true);
+    expect(state.saving).toBe(false);
+    expect(state.drafts.intro).toBe("morning words"); // draft kept for retry
+    expect(spy).toHaveBeenCalledOnce();
+    spy.mockRestore();
+  });
+
+  it("clears saveError on the next successful save", async () => {
+    let shouldFail = true;
+    mockSaveDay = () => (shouldFail ? Promise.reject(new Error("io")) : Promise.resolve());
+    useRitualStore.getState().setDraft("intro", "words");
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await useRitualStore.getState().saveNow();
+    expect(useRitualStore.getState().saveError).toBe(true);
+
+    shouldFail = false;
+    await useRitualStore.getState().saveNow();
+    spy.mockRestore();
+
+    const state = useRitualStore.getState();
+    expect(state.saveError).toBe(false);
+    expect(state.lastSavedAt).not.toBeNull();
   });
 });

--- a/homebase/src/store/ritual.ts
+++ b/homebase/src/store/ritual.ts
@@ -46,6 +46,11 @@ interface RitualState {
   accessError: boolean;
   loaded: boolean;
   saving: boolean;
+  // True when the last autosave write failed. Surfaced inline in the day
+  // footer (not the full-page recovery screen — a transient save failure
+  // shouldn't yank the user out of their editor). Mirrors the strategy
+  // page's saveStatus:"error" → SaveIndicator (#87).
+  saveError: boolean;
   lastSavedAt: number | null;
 
   loadToday: () => Promise<void>;
@@ -98,6 +103,7 @@ export const useRitualStore = create<RitualState>()((set, get) => ({
   accessError: false,
   loaded: false,
   saving: false,
+  saveError: false,
   lastSavedAt: null,
 
   loadToday: async () => {
@@ -186,10 +192,16 @@ export const useRitualStore = create<RitualState>()((set, get) => ({
     set({ saving: true });
     try {
       await saveDay(todayISO(), sections);
-      set({ saving: false, lastSavedAt: Date.now() });
+      set({ saving: false, saveError: false, lastSavedAt: Date.now() });
     } catch (err) {
-      set({ saving: false });
-      throw err;
+      // Autosave runs via `void saveNow()` (day.tsx), so a thrown error here is
+      // an unhandled rejection the user never sees, with the footer still
+      // showing a stale "saved …". Surface it as saveError instead and keep the
+      // drafts intact so the next edit retries. Inline severity on purpose — a
+      // transient save failure shouldn't escalate to the full-page recovery
+      // screen and pull the user out of their editor (#87).
+      console.error("ritual: autosave failed", err);
+      set({ saving: false, saveError: true });
     }
   },
 


### PR DESCRIPTION
Closes #87. The final link of the #80 → #83 → #85 → #87 read/write-swallow chain.

## Problem
`saveNow` rethrew on a write failure, and `day.tsx`'s `void saveNow()` (the 800ms autosave) swallowed it: no `console.error`, no UI, and the footer kept showing a stale "saved 9:14 am" — implying a save that never happened. The strategy page already handles this (`saveStatus:"error"` → `SaveIndicator`); the day page didn't.

## Fix
- **Store** (`store/ritual.ts`): new `saveError` flag. `saveNow` now logs and sets `saveError` on failure (cleared on the next successful save) instead of rethrowing, and **keeps `drafts` intact** so the next edit retries. Inline severity on purpose — a transient save failure must NOT escalate to the full-page `FolderAccessError` and pull the user out of their editor.
- **UI** (`routes/day.tsx`): the footer shows `saveError` — "couldn't save — check your folder" in red — instead of the stale saved label. Logic in a pure, exported `saveFooterText()`.

## Tested
- Store: write failure → `saveError`, `saving:false`, draft preserved, `saveNow` resolves (no unhandled rejection), logged once; `saveError` clears on the next successful save
- `saveFooterText`: saving / error / saved / retry-precedence branches
- Full suite: 188 pass; `tsc` + lint clean

## The chain is now closed
Every read/write rejection on both the strategy and day surfaces is now logged **and** user-visible: #80 (strategy reads), #83 (day reads), #85 (config read/write), #87 (autosave write). No remaining `void`-swallowed disk failure on either page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)