### PR TITLE
fix: surface settings config-write failures instead of a silent optimistic save

### DIFF
--- a/homebase/src/components/ConfigWriteErrorBanner.test.tsx
+++ b/homebase/src/components/ConfigWriteErrorBanner.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { ConfigWriteErrorBanner } from "./ConfigWriteErrorBanner";
+
+describe("ConfigWriteErrorBanner", () => {
+  it("warns that the change is shown but not saved, and points to reconnecting", () => {
+    render(<ConfigWriteErrorBanner />);
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/couldn.t be saved/i);
+    expect(alert).toHaveTextContent(/not written to disk/i);
+    expect(alert).toHaveTextContent(/Your folder/);
+  });
+});

--- a/homebase/src/components/ConfigWriteErrorBanner.tsx
+++ b/homebase/src/components/ConfigWriteErrorBanner.tsx
@@ -1,0 +1,17 @@
+// Inline banner on the settings (Customize) page, shown when a config change
+// failed to write to disk (ritual store `configWriteError`). The edit is kept
+// in memory so the user doesn't lose their work, but it isn't persisted — this
+// banner makes that explicit instead of letting the change look saved (#89).
+// Clears on its own once the next edit writes successfully.
+
+export function ConfigWriteErrorBanner() {
+  return (
+    <div role="alert" className="mb-6 rounded border border-[#FECACA] bg-[#FEF2F2] p-4">
+      <p className="font-serif text-[14px] leading-relaxed text-[#991B1B]">
+        Your last change couldn’t be saved to your folder — it’s shown here but not written to disk.
+        Your folder may be disconnected. Reconnect it under <strong>Your folder</strong> below, then
+        edit again to retry.
+      </p>
+    </div>
+  );
+}

--- a/homebase/src/components/WorkspaceSlot.tsx
+++ b/homebase/src/components/WorkspaceSlot.tsx
@@ -37,6 +37,7 @@ export function WorkspaceSlot({ config, initialDraft, onDraft }: WorkspaceSlotPr
         setLoaded(true);
       })
       .catch((err: unknown) => {
+        console.error("workspace slot: failed to load state", err);
         setLoadError(err instanceof Error ? err.message : String(err));
         setLoaded(true);
       });

--- a/homebase/src/components/WorkspaceSlot.tsx
+++ b/homebase/src/components/WorkspaceSlot.tsx
@@ -53,6 +53,7 @@ export function WorkspaceSlot({ config, initialDraft, onDraft }: WorkspaceSlotPr
       setPersistentDirty(false);
       setSaveError(null);
     } catch (err) {
+      console.error("workspace slot: failed to save state", err);
       setSaveError(err instanceof Error ? err.message : String(err));
     }
   }

--- a/homebase/src/routes/settings.tsx
+++ b/homebase/src/routes/settings.tsx
@@ -28,6 +28,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
+import { ConfigWriteErrorBanner } from "../components/ConfigWriteErrorBanner";
 import { FolderSection } from "../components/FolderSection";
 import { useRitualStore } from "../store/ritual";
 import type {
@@ -51,6 +52,7 @@ function SettingsPage() {
   const loadToday = useRitualStore((s) => s.loadToday);
   const updateConfig = useRitualStore((s) => s.updateConfig);
   const resetToDefaults = useRitualStore((s) => s.resetToDefaults);
+  const configWriteError = useRitualStore((s) => s.configWriteError);
 
   useEffect(() => {
     if (!loaded) void loadToday();
@@ -112,6 +114,8 @@ function SettingsPage() {
         <p className="mb-8 font-serif text-[14px] leading-relaxed text-[#6B7280]">
           Reorder, edit, or remove slots. Changes save automatically next to your day files.
         </p>
+
+        {configWriteError && <ConfigWriteErrorBanner />}
 
         <h2 className="mb-3 font-sans text-[10px] font-medium uppercase tracking-[0.18em] text-[#9CA3AF]">
           Your daily page

--- a/homebase/src/store/ritual.test.ts
+++ b/homebase/src/store/ritual.test.ts
@@ -50,6 +50,7 @@ beforeEach(() => {
     loaded: false,
     saving: false,
     saveError: false,
+    configWriteError: false,
     lastSavedAt: null,
   });
 });
@@ -353,5 +354,34 @@ describe("saveNow — autosave failures", () => {
     const state = useRitualStore.getState();
     expect(state.saveError).toBe(false);
     expect(state.lastSavedAt).not.toBeNull();
+  });
+});
+
+describe("updateConfig — write failures", () => {
+  it("surfaces a write failure as configWriteError, keeps the edit, doesn't throw", async () => {
+    useRitualStore.setState({ config: defaultConfig() });
+    mockWriteConfig = () => Promise.reject(new DOMException("denied", "NotAllowedError"));
+    const edited = { ...defaultConfig(), briefing: { enabled: false, quotes: [] } };
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // settings.tsx calls `await updateConfig(...)` / `void updateConfig(...)`
+    // with no catch — it must not reject.
+    await expect(useRitualStore.getState().updateConfig(() => edited)).resolves.toBeUndefined();
+
+    const state = useRitualStore.getState();
+    expect(state.configWriteError).toBe(true);
+    expect(state.config).toEqual(edited); // optimistic edit kept (don't lose user input)
+    expect(spy).toHaveBeenCalledOnce();
+    spy.mockRestore();
+  });
+
+  it("clears configWriteError on the next successful write", async () => {
+    useRitualStore.setState({ config: defaultConfig(), configWriteError: true });
+    mockWriteConfig = () => Promise.resolve();
+    const edited = { ...defaultConfig(), briefing: { enabled: false, quotes: [] } };
+
+    await useRitualStore.getState().updateConfig(() => edited);
+
+    expect(useRitualStore.getState().configWriteError).toBe(false);
   });
 });

--- a/homebase/src/store/ritual.ts
+++ b/homebase/src/store/ritual.ts
@@ -51,6 +51,11 @@ interface RitualState {
   // shouldn't yank the user out of their editor). Mirrors the strategy
   // page's saveStatus:"error" → SaveIndicator (#87).
   saveError: boolean;
+  // True when the last settings config write (updateConfig) failed. The edit
+  // is kept in memory (losing the user's input would be worse) but flagged so
+  // the settings page can show it didn't reach disk; cleared on the next
+  // successful write (#89).
+  configWriteError: boolean;
   lastSavedAt: number | null;
 
   loadToday: () => Promise<void>;
@@ -104,6 +109,7 @@ export const useRitualStore = create<RitualState>()((set, get) => ({
   loaded: false,
   saving: false,
   saveError: false,
+  configWriteError: false,
   lastSavedAt: null,
 
   loadToday: async () => {
@@ -210,8 +216,19 @@ export const useRitualStore = create<RitualState>()((set, get) => ({
     if (!current) return;
     const next = updater(current);
     if (next === current) return;
-    set({ config: next });
-    await writeConfig(next);
+    set({ config: next }); // optimistic — keep the settings UI responsive
+    try {
+      await writeConfig(next);
+      set({ configWriteError: false });
+    } catch (err) {
+      // Settings calls this via `await updateConfig(...)` / `void updateConfig(...)`
+      // with no catch, so a thrown rejection is unhandled and the change looks
+      // saved while disk never changed. Keep the in-memory edit (discarding the
+      // user's input would be worse) but flag it so the settings page shows it
+      // didn't persist; the next successful edit clears the flag (#89).
+      console.error("ritual: failed to write config", err);
+      set({ configWriteError: true });
+    }
   },
 
   resetToDefaults: async () => {

--- a/homebase/src/store/ritual.ts
+++ b/homebase/src/store/ritual.ts
@@ -226,6 +226,9 @@ export const useRitualStore = create<RitualState>()((set, get) => ({
       // saved while disk never changed. Keep the in-memory edit (discarding the
       // user's input would be worse) but flag it so the settings page shows it
       // didn't persist; the next successful edit clears the flag (#89).
+      // Surfaced inline (configWriteError → banner) rather than the full-page
+      // accessError even for a folder-access failure: on the settings page the
+      // user is already where they'd reconnect (the Your folder section).
       console.error("ritual: failed to write config", err);
       set({ configWriteError: true });
     }
@@ -245,7 +248,7 @@ export const useRitualStore = create<RitualState>()((set, get) => ({
       set({ accessError: true, configError: null, loaded: true });
       return;
     }
-    set({ configError: null });
+    set({ configError: null, configWriteError: false });
     await get().loadToday();
   },
 }));

--- a/homebase/src/store/strategy.test.ts
+++ b/homebase/src/store/strategy.test.ts
@@ -238,11 +238,14 @@ describe("StrategyStore", () => {
     const store = createStrategyStore(failingFs);
     await store.getState().expandRow("life-values");
     store.getState().setContent("life-values", "courage");
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     await expect(store.getState().flush("life-values")).rejects.toThrow("disk full");
 
     const row = store.getState().rows["life-values"];
     expect(row.saveStatus).toBe("error");
     expect(row.dirty).toBe(true); // content not lost; next edit/blur will retry
+    expect(spy).toHaveBeenCalledOnce(); // failure is logged, not just surfaced
+    spy.mockRestore();
   });
 
   it("resetSaveStatus brings saveStatus back to idle (consumer-driven settle)", async () => {

--- a/homebase/src/store/strategy.ts
+++ b/homebase/src/store/strategy.ts
@@ -279,7 +279,9 @@ export function createStrategyStore(fs: StrategyFsApi): UseBoundStore<StoreApi<S
         // Surface the failure via saveStatus="error" — the SaveIndicator
         // will render an error pip until the next successful save (or until
         // the user retries by editing again, which moves us to "saving").
-        // dirty stays true so the next edit/blur retries.
+        // dirty stays true so the next edit/blur retries. Log too, so a save
+        // failure leaves a console trace (callers swallow the rethrow).
+        console.error(`strategy: failed to save ${horizon}`, err);
         set((s) => ({
           rows: { ...s.rows, [horizon]: { ...s.rows[horizon], saveStatus: "error" } },
         }));


### PR DESCRIPTION
Closes #89. The same read/write-swallow bug class on a third surface (settings), found by the #88 review.

## Problem
`updateConfig` applied the change to in-memory state then wrote to disk **unguarded**. The settings page calls it via `await updateConfig(...)` / `void updateConfig(...)` with no try/catch, so a failed write was silent: no log, no UI, and because the in-memory `set` already applied, the change *looked* saved while disk never changed — gone on reload.

## Fix
- **Store** (`store/ritual.ts`): new `configWriteError` flag. `updateConfig` now guards the write — on failure it **keeps the in-memory edit** (discarding the user's input would be worse), logs, and sets `configWriteError`; cleared on the next successful write. Doesn't reject (the callers don't catch). Mirrors the day-autosave `saveError` pattern at inline severity.
- **UI** (`routes/settings.tsx` + `components/ConfigWriteErrorBanner.tsx`): a banner at the top of the settings page — "shown here but not written to disk… reconnect under Your folder, then edit again to retry" — appears while `configWriteError` is set and clears itself on the next successful edit.
- **Parity logging** (the review's minor notes): added `console.error` to `strategy.ts` `flush` and `WorkspaceSlot`'s save catch, so every save failure across the app leaves a console trace (both already surfaced in the UI; they just didn't log).

## Tested
- Store: write failure → `configWriteError`, edit kept, logged, `updateConfig` resolves (no unhandled rejection); clears on next successful write
- `ConfigWriteErrorBanner`: renders the not-saved warning + points to Your folder
- `strategy flush` test now also asserts the failure is logged
- Full suite: 191 pass; `tsc` + lint clean

## Chain status
The day + strategy surfaces were closed by #80/#83/#85/#87. This closes the **settings** surface — every read/write failure across all three surfaces is now logged and user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)