### PR TITLE
test: cover WorkspaceSlot save/load error paths

### DIFF
--- a/homebase/src/components/WorkspaceSlot.test.tsx
+++ b/homebase/src/components/WorkspaceSlot.test.tsx
@@ -106,7 +106,9 @@ describe("WorkspaceSlot", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/couldn.t load state/i)).toBeInTheDocument();
+      // Assert the actual error detail is surfaced, not just the static label —
+      // catches a regression that dropped the {loadError} interpolation.
+      expect(screen.getByText(/couldn.t load state/i)).toHaveTextContent(/permission revoked/);
     });
     // No editable surface rendered on a load failure.
     expect(container.querySelector("textarea")).toBeNull();

--- a/homebase/src/components/WorkspaceSlot.test.tsx
+++ b/homebase/src/components/WorkspaceSlot.test.tsx
@@ -1,19 +1,18 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vite-plus/test";
 import type { WorkspaceSlotConfig } from "../lib/config";
 
 // Mock the log module so WorkspaceSlot's useEffect doesn't try to touch
-// real FSAccess during tests. Each test seeds the in-memory store before
-// rendering. We need to declare the mock before importing the component
-// (Vitest hoists vi.mock).
+// real FSAccess during tests. readState/writeState are overridable per test
+// (default to the in-memory store) so the error-path tests can reject. We
+// declare the mock before importing the component (Vitest hoists vi.mock).
 const stateStore = new Map<string, string>();
+let mockReadState: (slot: string) => Promise<string>;
+let mockWriteState: (slot: string, text: string) => Promise<void>;
 
 vi.mock("../lib/log", () => ({
-  readState: (slot: string) => Promise.resolve(stateStore.get(slot) ?? ""),
-  writeState: (slot: string, text: string) => {
-    stateStore.set(slot, text);
-    return Promise.resolve();
-  },
+  readState: (slot: string) => mockReadState(slot),
+  writeState: (slot: string, text: string) => mockWriteState(slot, text),
 }));
 
 // Import AFTER the mock so the component picks up the mocked module.
@@ -27,6 +26,11 @@ const baseConfig: WorkspaceSlotConfig = {
 
 beforeEach(() => {
   stateStore.clear();
+  mockReadState = (slot) => Promise.resolve(stateStore.get(slot) ?? "");
+  mockWriteState = (slot, text) => {
+    stateStore.set(slot, text);
+    return Promise.resolve();
+  };
 });
 
 describe("WorkspaceSlot", () => {
@@ -91,5 +95,49 @@ describe("WorkspaceSlot", () => {
       <WorkspaceSlot config={baseConfig} initialDraft="" onDraft={() => {}} />,
     );
     expect(container.querySelector("textarea")).toBeNull();
+  });
+
+  it("shows an inline error (and logs) when persistent state fails to load", async () => {
+    mockReadState = () => Promise.reject(new DOMException("permission revoked", "NotAllowedError"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { container } = render(
+      <WorkspaceSlot config={baseConfig} initialDraft="" onDraft={() => {}} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/couldn.t load state/i)).toBeInTheDocument();
+    });
+    // No editable surface rendered on a load failure.
+    expect(container.querySelector("textarea")).toBeNull();
+    expect(spy).toHaveBeenCalledOnce();
+    spy.mockRestore();
+  });
+
+  it("shows 'save failed' (and logs) when a blur-save fails, keeping the text for retry", async () => {
+    mockWriteState = () => Promise.reject(new DOMException("denied", "NotAllowedError"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { container } = render(
+      <WorkspaceSlot config={baseConfig} initialDraft="" onDraft={() => {}} />,
+    );
+
+    const textarea = await waitFor(() => {
+      const el = container.querySelector("textarea");
+      if (!el) throw new Error("textarea not loaded yet");
+      return el;
+    });
+
+    // Edit (marks dirty) then blur to trigger the save.
+    fireEvent.change(textarea, { target: { value: "new goals" } });
+    fireEvent.blur(textarea);
+
+    await waitFor(() => {
+      expect(screen.getByText(/save failed:/i)).toBeInTheDocument();
+    });
+    // The user's text isn't discarded — they can retry.
+    expect((container.querySelector("textarea") as HTMLTextAreaElement).value).toBe("new goals");
+    expect(spy).toHaveBeenCalledOnce();
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
Closes #91. Test-only — no behavior change. Closes the last coverage gap from the #80→#89 swallow-chain audit.

## What
`WorkspaceSlot`'s two error branches (persistent-state load failure, blur-save failure) behave correctly (they log + surface inline, per #89/#90) but had zero test coverage — the existing `readState`/`writeState` mocks always resolved.

- Parameterized the mocks (`mockReadState`/`mockWriteState`, default to the in-memory store, overridable per test) — the 5 existing tests are unchanged in behavior.
- **Load failure:** rejecting `readState` → asserts the inline "couldn't load state" error renders, no editor mounts, and `console.error` is called.
- **Save failure:** rejecting `writeState` → type + blur → asserts "save failed" renders, the user's text is preserved (retry), and `console.error` is called.

## Tested
- `vp test run` — 193 pass (7 in WorkspaceSlot, +2 new); `tsc` + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)