### PR TITLE
docs: add CODE_OF_CONDUCT.md and ROADMAP.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+Homebase adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct.
+
+## The short version
+
+Be kind. Assume good faith. Disagree about ideas, not about people. Don't harass anyone — on this repo, in issues, in PRs, in Discussions, or anywhere else this project's name follows you.
+
+## Scope
+
+This applies in all project spaces: the GitHub repository (issues, PRs, Discussions, commit messages, code review), and anywhere a person is representing Homebase in public (talks, posts, demos).
+
+## Reporting
+
+If you see behavior that violates the code, or you experience it yourself, email Brandon at `afrobot@gmail.com`. Reports are handled privately. You won't be retaliated against for raising one in good faith, even if the eventual call goes against you.
+
+## Enforcement
+
+The maintainer (currently Brandon) is responsible for clarifying standards and responding to reports. Possible responses include a private clarification, a public correction, a temporary cool-off, or — for severe or repeated cases — a permanent ban from project spaces.
+
+The full Contributor Covenant text, including its detailed standards and enforcement guidelines, is the authoritative version of this policy. This file is the shortened in-repo pointer.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,42 @@
+# Roadmap
+
+Homebase is a personal-tool project, so this is a sketch, not a contract. The "shipping now" list is what's actively being worked on; "next" is what's most likely to land in the following weeks; "someday" is on the table but not scheduled.
+
+If you want to help with anything here, comment on the linked issue (or open one if it doesn't exist yet) before starting work — it saves both of us time.
+
+## Shipping now
+
+- Polishing the strategic accordion on `/` (the home page horizons surface).
+- Day-page autosave reliability and clearer error surfaces when writes fail.
+- General bug bash from real daily use — see [open issues](https://github.com/meninoebom/homebase/issues).
+
+## Next
+
+- Richer markdown editing inside slots — bold, headers, lists — without giving up the plain-text source of truth on disk. Tracked in [#75](https://github.com/meninoebom/homebase/issues/75).
+- Better first-run experience for users who haven't seen a File System Access permission prompt before.
+- A clearer story for "where do I back this up?" — likely a Customize-page hint pointing at `git init`.
+- More languages for the default prompt set. English is the only one shipping today; translations are a great way to contribute without touching the build.
+
+## Someday
+
+- Optional iCloud / Dropbox / git-sync helpers for users who want their homebase folder to follow them across machines. The constraint: the source of truth has to stay "your folder on disk" — no Homebase-hosted backend.
+- A slot kind for recurring practices with reps or streaks. Only if it can be done without becoming a habit-tracker app — see the "Adding a slot kind" note in [CONTRIBUTING.md](CONTRIBUTING.md).
+- A briefing source pluggable enough that someone can point it at their own quote file, RSS feed, or local note.
+- Mobile. Currently desktop-Chromium only, because the File System Access API isn't on mobile Safari or Firefox. If that changes, mobile becomes interesting.
+
+## Explicit non-goals
+
+- Accounts, login, sync server, telemetry. None of these. Your data lives on your disk; the app is a static site.
+- A plugin marketplace. The codebase is small enough to fork; that's the plugin system.
+- Becoming a general-purpose note-taking app. Homebase is for a specific shape of personal writing practice; if you want Obsidian, use Obsidian.
+
+## How priorities get set
+
+Roughly in this order:
+
+1. Things that are broken for someone's daily use.
+2. Things that lower the barrier for new contributors (docs, scoped issues, first-run polish).
+3. Things I personally want to use tomorrow.
+4. Everything else.
+
+If you think something should jump the queue, open a Discussion and make the case.


### PR DESCRIPTION
## Summary

- Adds `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1 pointer with a short in-repo summary). CONTRIBUTING.md was already linking to this file but the file itself was missing.
- Adds `ROADMAP.md` with shipping-now / next / someday / non-goals sections so prospective contributors can see where they can plug in.
- Sets the GitHub repo description and labels #75 as \`help wanted\` (done outside this PR via \`gh\`).

## Test plan

- [x] N/A (docs only)