### PR TITLE
feat: seed example.md into fresh folder on first run

### DIFF
--- a/homebase/src/store/ritual.test.ts
+++ b/homebase/src/store/ritual.test.ts
@@ -8,6 +8,8 @@ import type { HomebaseConfig, ReadConfigResult } from "../lib/config";
 let mockReadConfig: () => Promise<ReadConfigResult>;
 let mockWriteConfig: (config: HomebaseConfig) => Promise<void>;
 let mockListFiles: () => Promise<string[]>;
+let mockReadFile: (name: string) => Promise<string>;
+let mockWriteFile: (name: string, text: string) => Promise<void>;
 let mockReadDaySections: () => Promise<Record<string, string>>;
 let mockSaveDay: () => Promise<void>;
 
@@ -22,6 +24,8 @@ vi.mock("../lib/config", async () => {
 
 vi.mock("../lib/fs", () => ({
   listTopLevelFiles: () => mockListFiles(),
+  readFile: (name: string) => mockReadFile(name),
+  writeFile: (name: string, text: string) => mockWriteFile(name, text),
 }));
 
 vi.mock("../lib/log", () => ({
@@ -38,6 +42,8 @@ beforeEach(() => {
   mockReadConfig = () => Promise.resolve({ kind: "missing" });
   mockWriteConfig = () => Promise.resolve();
   mockListFiles = () => Promise.resolve([]);
+  mockReadFile = () => Promise.resolve(""); // "" means file absent
+  mockWriteFile = () => Promise.resolve();
   mockReadDaySections = () => Promise.resolve({});
   mockSaveDay = () => Promise.resolve();
   // Reset singleton state between tests.
@@ -112,6 +118,99 @@ describe("loadToday — config seeding", () => {
 
     expect(wrote).toBe(false);
     expect(useRitualStore.getState().config).toEqual(existing);
+  });
+});
+
+describe("loadToday — example.md seeding", () => {
+  it("writes example.md on fresh first-run (no day files, no config)", async () => {
+    const written: Record<string, string> = {};
+    mockWriteFile = (name, text) => {
+      written[name] = text;
+      return Promise.resolve();
+    };
+    mockListFiles = () => Promise.resolve([]);
+    mockReadFile = () => Promise.resolve(""); // example.md absent
+
+    await useRitualStore.getState().loadToday();
+
+    expect(written["example.md"]).toBeDefined();
+    // Must open with an edit-or-delete line.
+    expect(written["example.md"]).toMatch(/edit|delete/i);
+  });
+
+  it("does not write example.md when day files already exist (migrating user)", async () => {
+    const written: Record<string, string> = {};
+    mockWriteFile = (name, text) => {
+      written[name] = text;
+      return Promise.resolve();
+    };
+    mockListFiles = () => Promise.resolve(["2026-05-07.md", "2026-05-08.md"]);
+    mockReadFile = () => Promise.resolve("");
+
+    await useRitualStore.getState().loadToday();
+
+    expect(written["example.md"]).toBeUndefined();
+  });
+
+  it("does not re-write example.md when it already exists (idempotent)", async () => {
+    let writeCount = 0;
+    mockWriteFile = () => {
+      writeCount++;
+      return Promise.resolve();
+    };
+    mockListFiles = () => Promise.resolve([]);
+    // example.md already present — non-empty string means it exists.
+    mockReadFile = (name) =>
+      name === "example.md"
+        ? Promise.resolve("# This is an example\nEdit or delete it.")
+        : Promise.resolve("");
+
+    await useRitualStore.getState().loadToday();
+
+    expect(writeCount).toBe(0);
+  });
+
+  it("does not re-write example.md on second load / permission reconnect", async () => {
+    // First load: fresh, example.md absent → writes it.
+    let exampleContent = "";
+    mockWriteFile = (name, text) => {
+      if (name === "example.md") exampleContent = text;
+      return Promise.resolve();
+    };
+    mockListFiles = () => Promise.resolve([]);
+    mockReadFile = () => Promise.resolve(""); // absent on first load
+
+    await useRitualStore.getState().loadToday();
+    expect(exampleContent).not.toBe("");
+
+    // Second load: example.md now present → must not write again.
+    let secondWriteCount = 0;
+    mockWriteFile = () => {
+      secondWriteCount++;
+      return Promise.resolve();
+    };
+    mockReadFile = (name) =>
+      name === "example.md" ? Promise.resolve(exampleContent) : Promise.resolve("");
+    mockReadConfig = () => Promise.resolve({ kind: "ok", config: defaultConfig() });
+    useRitualStore.setState({ loaded: false });
+
+    await useRitualStore.getState().loadToday();
+
+    expect(secondWriteCount).toBe(0);
+  });
+
+  it("does not throw when the seed write fails — app still loads", async () => {
+    mockWriteFile = () => Promise.reject(new Error("disk full"));
+    mockListFiles = () => Promise.resolve([]);
+    mockReadFile = () => Promise.resolve("");
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(useRitualStore.getState().loadToday()).resolves.toBeUndefined();
+
+    const state = useRitualStore.getState();
+    expect(state.loaded).toBe(true);
+    expect(state.accessError).toBe(false);
+    spy.mockRestore();
   });
 });
 

--- a/homebase/src/store/ritual.ts
+++ b/homebase/src/store/ritual.ts
@@ -18,7 +18,7 @@ import {
   writeConfig,
   type HomebaseConfig,
 } from "../lib/config";
-import { listTopLevelFiles } from "../lib/fs";
+import { listTopLevelFiles, readFile, writeFile } from "../lib/fs";
 import { readDaySections, saveDay, todayISO } from "../lib/log";
 
 export type SlotId = string;
@@ -93,11 +93,54 @@ function isAccessError(err: unknown): boolean {
  * user is mid-flow on a pre-config build (Brandon, anyone migrating)
  * — give them the legacy slot set so nothing visibly changes. Otherwise
  * they're a fresh install — give them the neutral default.
+ *
+ * Returns `isFresh: true` for a genuinely new folder with no day files,
+ * so the caller can decide whether to seed helper files (example.md).
  */
-async function pickFirstRunConfig(): Promise<HomebaseConfig> {
+async function pickFirstRunConfig(): Promise<{ config: HomebaseConfig; isFresh: boolean }> {
   const files = await listTopLevelFiles();
   const hasExistingDays = files.some((name) => DAY_FILE_PATTERN.test(name));
-  return hasExistingDays ? legacyDefaultConfig() : defaultConfig();
+  return {
+    config: hasExistingDays ? legacyDefaultConfig() : defaultConfig(),
+    isFresh: !hasExistingDays,
+  };
+}
+
+const EXAMPLE_FILENAME = "example.md";
+
+// The starter file written into a genuinely fresh folder on first run.
+// Opens with an edit-or-delete line so newcomers know it's safe to touch,
+// then models what a day entry feels like — in Homebase's editorial voice.
+const EXAMPLE_CONTENT = `<!-- Edit or delete this file — it's here to show you the shape of a day entry. -->
+
+# A morning to begin
+
+Something shifted this week. Not in one clean moment — more like a door
+that had been ajar finally opened all the way.
+
+---
+
+**What matters today:** one clear thing, written plainly.
+
+**What I'm sitting with:** a question I don't have to answer yet.
+
+**One line for tonight:** what I want to remember about this morning.
+`;
+
+/**
+ * On a genuinely fresh first run (no day files, no pre-existing example.md),
+ * write a starter example.md so a newcomer has a real entry to imitate.
+ * Non-fatal: a write failure is logged but does not block app load.
+ */
+async function maybeSeedExampleFile(): Promise<void> {
+  try {
+    const existing = await readFile(EXAMPLE_FILENAME);
+    if (existing !== "") return; // already present — don't overwrite
+    await writeFile(EXAMPLE_FILENAME, EXAMPLE_CONTENT);
+  } catch (err) {
+    console.error("ritual: failed to write example.md seed file", err);
+    // Intentionally non-fatal — the app continues normally.
+  }
 }
 
 export const useRitualStore = create<RitualState>()((set, get) => ({
@@ -122,8 +165,14 @@ export const useRitualStore = create<RitualState>()((set, get) => ({
       let config: HomebaseConfig;
       const result = await readConfig();
       if (result.kind === "missing") {
-        config = await pickFirstRunConfig();
+        const { config: firstRunConfig, isFresh } = await pickFirstRunConfig();
+        config = firstRunConfig;
         await writeConfig(config);
+        // Fresh users (no existing day files) get a starter example.md so
+        // they have something to imitate, not a blank surface. Non-fatal.
+        if (isFresh) {
+          await maybeSeedExampleFile();
+        }
       } else if (result.kind === "parse-error" || result.kind === "schema-error") {
         set({ configError: result, draftsError: false, accessError: false, loaded: true });
         return;


### PR DESCRIPTION
## Summary

- On a genuinely fresh first-run (empty folder, no config), writes a standalone `example.md` so newcomers have a real day entry to imitate rather than a blank surface.
- Seeding is idempotent: `maybeSeedExampleFile()` reads before writing — if `example.md` already exists (second load, reconnect, or the user deleted-then-restored), it's skipped. A deleted file stays deleted forever.
- Migrating users (folder already has `YYYY-MM-DD.md` day files) are never seeded.
- Seed write failure is non-fatal: logged via `console.error`, the app loads normally regardless.

## Implementation

- `pickFirstRunConfig()` now returns `{ config, isFresh }` so the caller knows whether to seed without an extra filesystem scan.
- Hook point is the `result.kind === "missing"` branch in `loadToday`, after the config write, gated on `isFresh`.
- Five new tests in `ritual.test.ts`: fresh→write, migrating→no-write, already-present→no-rewrite, second-load→no-rewrite, write-failure→non-fatal.

## Test plan

- [x] `pnpm test` — 198 tests pass (24 test files)
- [x] `pnpm check` — format and lint clean

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)