### PR TITLE
fix(feedback): prevent focus stealing on app load

### DIFF
--- a/homebase/src/components/FeedbackModal.test.tsx
+++ b/homebase/src/components/FeedbackModal.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { FeedbackLink, FeedbackModal, FEEDBACK_EMAIL } from "./FeedbackModal";
+
+describe("FeedbackModal", () => {
+  it("renders a Feedback button trigger", () => {
+    render(<FeedbackLink onOpen={() => {}} />);
+    expect(screen.getByRole("button", { name: /feedback/i })).toBeInTheDocument();
+  });
+
+  it("does not show the modal when closed", () => {
+    render(<FeedbackModal isOpen={false} onClose={() => {}} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows the dialog when open", () => {
+    render(<FeedbackModal isOpen={true} onClose={() => {}} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("renders a mailto link pointing to the feedback email constant", () => {
+    render(<FeedbackModal isOpen={true} onClose={() => {}} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", expect.stringContaining(FEEDBACK_EMAIL));
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    const onClose = vi.fn();
+    render(<FeedbackModal isOpen={true} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the backdrop is clicked", () => {
+    const onClose = vi.fn();
+    render(<FeedbackModal isOpen={true} onClose={onClose} />);
+    // The backdrop is the outer div with data-testid="feedback-backdrop"
+    fireEvent.click(screen.getByTestId("feedback-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT close when clicking the dialog itself", () => {
+    const onClose = vi.fn();
+    render(<FeedbackModal isOpen={true} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("dialog"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe("FEEDBACK_EMAIL constant", () => {
+  it("is a non-empty string", () => {
+    expect(typeof FEEDBACK_EMAIL).toBe("string");
+    expect(FEEDBACK_EMAIL.length).toBeGreaterThan(0);
+  });
+});

--- a/homebase/src/components/FeedbackModal.tsx
+++ b/homebase/src/components/FeedbackModal.tsx
@@ -74,13 +74,15 @@ interface FeedbackModalProps {
 
 export function FeedbackModal({ isOpen, onClose, triggerRef }: FeedbackModalProps) {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const hasBeenOpenRef = useRef(false);
 
-  // Move focus to the close button when the modal opens.
+  // Move focus to the close button when the modal opens; restore on close.
+  // hasBeenOpenRef guards against the else branch running on initial mount.
   useEffect(() => {
     if (isOpen) {
+      hasBeenOpenRef.current = true;
       closeButtonRef.current?.focus();
-    } else {
-      // Restore focus to the trigger when the modal closes.
+    } else if (hasBeenOpenRef.current) {
       triggerRef?.current?.focus();
     }
   }, [isOpen, triggerRef]);

--- a/homebase/src/components/FeedbackModal.tsx
+++ b/homebase/src/components/FeedbackModal.tsx
@@ -1,0 +1,192 @@
+// FeedbackModal — a reusable feedback link + dismissable modal.
+//
+// The modal body is a mailto: link built from a single build-time constant
+// (FEEDBACK_EMAIL). To swap to a hosted form in the future, update the
+// constant and the modal body — nothing else changes.
+//
+// Design rooms (per CLAUDE.md "Two rooms, two registers"):
+//   - Strategic accordion (/) — warm bone surface, marigold accent, uppercase
+//     small-caps label. FeedbackLink accepts a `variant` prop to match.
+//   - Day surface (/day) — white surface, gray text, 13px/600 weight.
+//
+// A11y:
+//   - role="dialog" + aria-modal="true" on the dialog panel.
+//   - Esc closes via keydown listener on document.
+//   - Backdrop click closes; click on the panel itself does not.
+//   - Focus is moved to the close button on open and restored to the trigger
+//     on close via a ref passed from the caller (optional — graceful
+//     degradation if not supplied).
+
+import { useEffect, useRef } from "react";
+
+export const FEEDBACK_EMAIL = "afrobot@gmail.com";
+
+const MAILTO_HREF = `mailto:${FEEDBACK_EMAIL}?subject=Homebase%20feedback`;
+
+// ─── FeedbackLink ────────────────────────────────────────────────────────────
+
+interface FeedbackLinkProps {
+  onOpen: () => void;
+  /** "strategic" = warm bone / marigold register (/); "day" = white register (/day). */
+  variant?: "strategic" | "day";
+  /** Ref forwarded from the caller so focus can be restored on close. */
+  triggerRef?: React.RefObject<HTMLButtonElement | null>;
+}
+
+export function FeedbackLink({ onOpen, variant = "day", triggerRef }: FeedbackLinkProps) {
+  const isStrategic = variant === "strategic";
+  return (
+    <button
+      ref={triggerRef}
+      type="button"
+      onClick={onOpen}
+      className="cursor-pointer border-0 bg-transparent p-0 transition-colors"
+      style={
+        isStrategic
+          ? {
+              fontFamily: "var(--font-sans-ui)",
+              fontSize: "12px",
+              fontWeight: 600,
+              letterSpacing: "0.16em",
+              textTransform: "uppercase",
+              color: "var(--ink-3)",
+            }
+          : {
+              fontSize: "13px",
+              fontWeight: 600,
+              color: "#6B7280",
+            }
+      }
+    >
+      Feedback
+    </button>
+  );
+}
+
+// ─── FeedbackModal ───────────────────────────────────────────────────────────
+
+interface FeedbackModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Optional ref to the trigger button — focus is restored on close. */
+  triggerRef?: React.RefObject<HTMLButtonElement | null>;
+}
+
+export function FeedbackModal({ isOpen, onClose, triggerRef }: FeedbackModalProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Move focus to the close button when the modal opens.
+  useEffect(() => {
+    if (isOpen) {
+      closeButtonRef.current?.focus();
+    } else {
+      // Restore focus to the trigger when the modal closes.
+      triggerRef?.current?.focus();
+    }
+  }, [isOpen, triggerRef]);
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    // Backdrop
+    <div
+      data-testid="feedback-backdrop"
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        backgroundColor: "rgba(0, 0, 0, 0.35)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 50,
+      }}
+    >
+      {/* Dialog panel — stop propagation so clicks inside don't close */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="feedback-modal-title"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "var(--paper-1, #ECE6DA)",
+          borderRadius: "4px",
+          padding: "32px 36px",
+          maxWidth: "480px",
+          width: "90vw",
+          position: "relative",
+          fontFamily: "var(--font-sans-ui, 'Inter Tight', sans-serif)",
+        }}
+      >
+        {/* Close button */}
+        <button
+          ref={closeButtonRef}
+          type="button"
+          onClick={onClose}
+          aria-label="Close feedback modal"
+          style={{
+            position: "absolute",
+            top: "12px",
+            right: "14px",
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            fontSize: "18px",
+            lineHeight: 1,
+            color: "var(--ink-3, #7A7268)",
+          }}
+        >
+          ×
+        </button>
+
+        <h2
+          id="feedback-modal-title"
+          style={{
+            margin: "0 0 12px",
+            fontSize: "18px",
+            fontWeight: 600,
+            color: "var(--ink-1, #1A1613)",
+            letterSpacing: "-0.02em",
+          }}
+        >
+          Send feedback
+        </h2>
+
+        <p
+          style={{
+            margin: "0 0 20px",
+            fontSize: "14px",
+            lineHeight: 1.55,
+            color: "var(--ink-2, #3D3830)",
+          }}
+        >
+          Found a bug or have an idea? Send an email — it goes straight to the person building this.
+        </p>
+
+        <a
+          href={MAILTO_HREF}
+          style={{
+            display: "inline-block",
+            fontSize: "14px",
+            fontWeight: 600,
+            color: "var(--accent-2, #C18A2A)",
+            textDecoration: "underline",
+            letterSpacing: "-0.01em",
+          }}
+        >
+          Email {FEEDBACK_EMAIL}
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/homebase/src/routes/day.tsx
+++ b/homebase/src/routes/day.tsx
@@ -12,9 +12,10 @@
 // index.css for the broader two-rooms rationale.
 
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { DayLoadError } from "../components/DayLoadError";
+import { FeedbackLink, FeedbackModal } from "../components/FeedbackModal";
 import { FolderAccessError } from "../components/FolderAccessError";
 import { PromptSlot } from "../components/PromptSlot";
 import { WorkspaceSlot } from "../components/WorkspaceSlot";
@@ -43,6 +44,8 @@ export function saveFooterText(saving: boolean, saveError: boolean, savedLabel: 
 
 function DayPage() {
   const navigate = useNavigate();
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const feedbackTriggerRef = useRef<HTMLButtonElement | null>(null);
   const loadToday = useRitualStore((s) => s.loadToday);
   const setDraft = useRitualStore((s) => s.setDraft);
   const saveNow = useRitualStore((s) => s.saveNow);
@@ -169,14 +172,21 @@ function DayPage() {
         className="sticky bottom-0 flex items-center justify-between border-t border-[#EBEBEB] bg-white px-6 py-2"
         style={{ fontFamily: DAY_SANS }}
       >
-        <button
-          type="button"
-          onClick={() => navigate({ to: "/settings" })}
-          className="cursor-pointer border-0 bg-transparent p-0 transition-colors hover:text-[#111]"
-          style={{ fontSize: "13px", fontWeight: 600, color: "#6B7280" }}
-        >
-          Customize
-        </button>
+        <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={() => navigate({ to: "/settings" })}
+            className="cursor-pointer border-0 bg-transparent p-0 transition-colors hover:text-[#111]"
+            style={{ fontSize: "13px", fontWeight: 600, color: "#6B7280" }}
+          >
+            Customize
+          </button>
+          <FeedbackLink
+            variant="day"
+            onOpen={() => setFeedbackOpen(true)}
+            triggerRef={feedbackTriggerRef}
+          />
+        </div>
         <span
           style={{
             fontSize: "13px",
@@ -187,6 +197,11 @@ function DayPage() {
           {saveFooterText(saving, saveError, savedLabel)}
         </span>
       </footer>
+      <FeedbackModal
+        isOpen={feedbackOpen}
+        onClose={() => setFeedbackOpen(false)}
+        triggerRef={feedbackTriggerRef}
+      />
     </main>
   );
 }

--- a/homebase/src/routes/index.tsx
+++ b/homebase/src/routes/index.tsx
@@ -13,6 +13,8 @@
 // trip; persistent reload state is out of scope for v1.
 
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useRef, useState } from "react";
+import { FeedbackLink, FeedbackModal } from "../components/FeedbackModal";
 import { HorizonRow } from "../components/HorizonRow";
 import { Masthead } from "../components/Masthead";
 
@@ -22,6 +24,8 @@ export const Route = createFileRoute("/")({
 
 function StrategyAccordion() {
   const navigate = useNavigate();
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const feedbackTriggerRef = useRef<HTMLButtonElement | null>(null);
   return (
     <div className="strategy-scope min-h-screen">
       <div className="mx-auto max-w-[1040px] px-10 pt-14 pb-16 md:px-20">
@@ -35,7 +39,7 @@ function StrategyAccordion() {
           <HorizonRow horizon="day" onDayClick={() => navigate({ to: "/day" })} />
         </div>
         <footer className="mt-14 pt-5" style={{ borderTop: "1px solid var(--paper-edge)" }}>
-          <div className="mb-5 text-center">
+          <div className="mb-5 flex items-center justify-center gap-6">
             <button
               type="button"
               onClick={() => navigate({ to: "/settings" })}
@@ -51,7 +55,17 @@ function StrategyAccordion() {
             >
               Customize
             </button>
+            <FeedbackLink
+              variant="strategic"
+              onOpen={() => setFeedbackOpen(true)}
+              triggerRef={feedbackTriggerRef}
+            />
           </div>
+          <FeedbackModal
+            isOpen={feedbackOpen}
+            onClose={() => setFeedbackOpen(false)}
+            triggerRef={feedbackTriggerRef}
+          />
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div
               style={{


### PR DESCRIPTION
## Summary
- `FeedbackModal`'s focus `useEffect` ran on mount with `isOpen=false`, hitting the restore-focus branch and moving focus to the Feedback button before the user touched anything
- Added `hasBeenOpenRef` so focus only restores to the trigger after the modal has actually been opened at least once

## Test plan
- [ ] Load the app — Feedback button should have no focus ring
- [ ] Open and close the modal — focus should return to Feedback button after close

🤖 Generated with [Claude Code](https://claude.com/claude-code)