### PR TITLE
feat: /integrations page + portable reflection skill

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,6 +12,7 @@ If you want to help with anything here, comment on the linked issue (or open one
 
 ## Next
 
+- **Reflect with AI.** Your entries are plain markdown, which makes them easy to hand to an assistant for reflection. Shipping in stages: (1) the `/integrations` page and a portable reflection skill that teaches any local agent your folder layout, so you can point Claude Desktop or Claude Code at your folder today; (2) an opt-in in-app "Reflect" chat where you plug in your own bot — a local model (no key, nothing leaves your machine) or your own API key. The source of truth stays your folder; there is no Homebase-hosted model or backend.
 - Richer markdown editing inside slots — bold, headers, lists — without giving up the plain-text source of truth on disk. Tracked in [#75](https://github.com/meninoebom/homebase/issues/75).
 - Better first-run experience for users who haven't seen a File System Access permission prompt before.
 - A clearer story for "where do I back this up?" — likely a Customize-page hint pointing at `git init`.

--- a/homebase/src/lib/reflect/digest.test.ts
+++ b/homebase/src/lib/reflect/digest.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildDigest, isCorpusFile, isDayLogFile, isStrategyFile } from "./digest";
+
+// Anchor "today" so the window math is deterministic.
+const NOW = new Date(Date.UTC(2026, 5, 9, 12)); // 2026-06-09
+
+describe("isDayLogFile", () => {
+  it("matches dated daily-entry files", () => {
+    expect(isDayLogFile("2026-06-09.md")).toBe(true);
+    expect(isDayLogFile("1999-01-01.md")).toBe(true);
+  });
+
+  it("rejects strategy files and non-day names", () => {
+    expect(isDayLogFile("values.md")).toBe(false);
+    expect(isDayLogFile("year-2026.md")).toBe(false);
+    expect(isDayLogFile("2026-06-09.txt")).toBe(false);
+    expect(isDayLogFile("notes.md")).toBe(false);
+  });
+});
+
+describe("isStrategyFile", () => {
+  it("matches fixed-name and horizon-prefixed strategy files", () => {
+    expect(isStrategyFile("values.md")).toBe(true);
+    expect(isStrategyFile("life-goals.md")).toBe(true);
+    expect(isStrategyFile("year-2026.md")).toBe(true);
+    expect(isStrategyFile("month-2026-06.md")).toBe(true);
+    expect(isStrategyFile("week-2026-W24.md")).toBe(true);
+  });
+
+  it("rejects day logs and unrelated files", () => {
+    expect(isStrategyFile("2026-06-09.md")).toBe(false);
+    expect(isStrategyFile("homebase.config.json")).toBe(false);
+    expect(isStrategyFile("values.txt")).toBe(false);
+  });
+});
+
+describe("isCorpusFile", () => {
+  it("is the union of day logs and strategy files", () => {
+    expect(isCorpusFile("2026-06-09.md")).toBe(true);
+    expect(isCorpusFile("values.md")).toBe(true);
+    expect(isCorpusFile("homebase.config.json")).toBe(false);
+  });
+});
+
+describe("buildDigest", () => {
+  it("includes recent daily entries newest-first and the strategy files", () => {
+    const out = buildDigest(
+      [
+        { name: "values.md", text: "Be present." },
+        { name: "year-2026.md", text: "Ship Homebase." },
+        { name: "2026-06-09.md", text: "Today I wrote." },
+        { name: "2026-06-07.md", text: "Two days ago." },
+      ],
+      { now: NOW, days: 30 },
+    );
+
+    expect(out).toContain("## Strategy");
+    expect(out).toContain("### values.md");
+    expect(out).toContain("Be present.");
+    expect(out).toContain("## Daily entries (last 30 days)");
+    // Newest first: 06-09 must appear before 06-07.
+    expect(out.indexOf("### 2026-06-09")).toBeLessThan(out.indexOf("### 2026-06-07"));
+    // Day headings drop the .md extension.
+    expect(out).not.toContain("2026-06-09.md");
+  });
+
+  it("excludes daily entries older than the window", () => {
+    const out = buildDigest(
+      [
+        { name: "2026-06-09.md", text: "in window" },
+        { name: "2026-04-01.md", text: "too old" },
+      ],
+      { now: NOW, days: 30 },
+    );
+
+    expect(out).toContain("in window");
+    expect(out).not.toContain("too old");
+  });
+
+  it("skips empty files so the digest is signal, not scaffolding", () => {
+    const out = buildDigest(
+      [
+        { name: "values.md", text: "   \n  " },
+        { name: "2026-06-09.md", text: "" },
+      ],
+      { now: NOW, days: 30 },
+    );
+
+    expect(out).not.toContain("### values.md");
+    expect(out).not.toContain("## Daily entries");
+    expect(out).toContain("No entries found yet");
+  });
+
+  it("includes today (zero-day diff) and the last day of the window", () => {
+    const out = buildDigest(
+      [
+        { name: "2026-06-09.md", text: "today" }, // diff 0
+        { name: "2026-05-11.md", text: "edge in" }, // diff 29, inside days=30
+        { name: "2026-05-10.md", text: "edge out" }, // diff 30, outside
+      ],
+      { now: NOW, days: 30 },
+    );
+
+    expect(out).toContain("today");
+    expect(out).toContain("edge in");
+    expect(out).not.toContain("edge out");
+  });
+});

--- a/homebase/src/lib/reflect/digest.ts
+++ b/homebase/src/lib/reflect/digest.ts
@@ -1,0 +1,141 @@
+// Build a single-markdown "reflection digest" from the Homebase folder, ready
+// to paste into any AI chat. This is the data half of the AI integration: the
+// primer teaches the agent *how* to read; the digest hands it *what* to read.
+//
+// Everything here is deliberately split into a pure assembler (`buildDigest`,
+// takes files in, returns a string) and a thin filesystem wrapper
+// (`gatherDigest`, reads the folder then calls the assembler). The pure half
+// is unit-tested without any File System Access mocking.
+//
+// Privacy posture: the digest is assembled entirely in the browser and only
+// ever reaches the clipboard. Nothing is sent anywhere — where it goes next is
+// the user's choice (paste into Claude, ChatGPT, a local model, whatever).
+
+import { listTopLevelFiles, readFile } from "../fs";
+
+export interface CorpusFile {
+  name: string;
+  text: string;
+}
+
+export interface DigestOptions {
+  /** "Today" — the window anchor. Injected so the assembler stays pure/testable. */
+  now: Date;
+  /** How many days back of daily entries to include (inclusive of today). */
+  days: number;
+}
+
+// `YYYY-MM-DD.md` — the dated daily-entry log files.
+const DAY_LOG_RE = /^(\d{4})-(\d{2})-(\d{2})\.md$/;
+
+// Strategy files all carry a fixed name or a horizon prefix, so they never
+// collide with the date-named logs. (`day-` is intentionally excluded: the
+// daily logs already cover that horizon, and a `day-…` prefix would be
+// ambiguous next to `YYYY-MM-DD.md`.)
+const STRATEGY_NAMES = new Set(["values.md", "life-goals.md"]);
+const STRATEGY_PREFIXES = ["year-", "month-", "week-"];
+
+const MS_PER_DAY = 86_400_000;
+
+/** True for a dated daily-entry file like `2026-06-09.md`. */
+export function isDayLogFile(name: string): boolean {
+  return DAY_LOG_RE.test(name);
+}
+
+/** True for a strategy file (`values.md`, `life-goals.md`, `year-…`, …). */
+export function isStrategyFile(name: string): boolean {
+  if (!name.endsWith(".md")) return false;
+  if (STRATEGY_NAMES.has(name)) return true;
+  return STRATEGY_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+/** True for any file the digest cares about — used to avoid reading the rest. */
+export function isCorpusFile(name: string): boolean {
+  return isDayLogFile(name) || isStrategyFile(name);
+}
+
+/** Parse the date out of a day-log filename, or null if it isn't one. */
+function dayLogDate(name: string): Date | null {
+  const m = DAY_LOG_RE.exec(name);
+  if (!m) return null;
+  // Noon UTC dodges any daylight-saving / timezone boundary surprises when we
+  // only care about whole-day differences.
+  return new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 12));
+}
+
+/** Whole-day difference (a − b), ignoring time of day. */
+function wholeDayDiff(a: Date, b: Date): number {
+  const au = Date.UTC(a.getUTCFullYear(), a.getUTCMonth(), a.getUTCDate());
+  const bu = Date.UTC(b.getUTCFullYear(), b.getUTCMonth(), b.getUTCDate());
+  return Math.round((au - bu) / MS_PER_DAY);
+}
+
+/**
+ * Assemble the digest markdown from a set of files. Pure: no filesystem, no
+ * clock — pass `now` in. Empty files are skipped so the digest is signal, not
+ * scaffolding. Returns a friendly note rather than an empty string when there's
+ * nothing to include yet.
+ */
+export function buildDigest(files: CorpusFile[], opts: DigestOptions): string {
+  const { now, days } = opts;
+
+  const dayLogs = files
+    .filter((f) => isDayLogFile(f.name) && f.text.trim().length > 0)
+    .filter((f) => {
+      const date = dayLogDate(f.name);
+      if (!date) return false;
+      const diff = wholeDayDiff(now, date);
+      return diff >= 0 && diff < days;
+    })
+    // Newest first.
+    .sort((a, b) => b.name.localeCompare(a.name));
+
+  const strategy = files
+    .filter((f) => isStrategyFile(f.name) && f.text.trim().length > 0)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const sections: string[] = [
+    "# My Homebase reflection digest",
+    `This is a snapshot of my own journaling and planning files (last ${days} days of daily entries, plus my strategy files). Read it as my private writing and help me reflect on it.`,
+  ];
+
+  if (strategy.length > 0) {
+    sections.push("## Strategy");
+    for (const f of strategy) {
+      sections.push(`### ${f.name}\n\n${f.text.trim()}`);
+    }
+  }
+
+  if (dayLogs.length > 0) {
+    sections.push(`## Daily entries (last ${days} days)`);
+    for (const f of dayLogs) {
+      // Strip the `.md` for a cleaner date heading.
+      const heading = f.name.replace(/\.md$/, "");
+      sections.push(`### ${heading}\n\n${f.text.trim()}`);
+    }
+  }
+
+  if (strategy.length === 0 && dayLogs.length === 0) {
+    sections.push(
+      "_No entries found yet. Write a few daily pages or fill in your values, then try again._",
+    );
+  }
+
+  return `${sections.join("\n\n")}\n`;
+}
+
+/**
+ * Read the relevant files from the Homebase folder and build the digest. Only
+ * touches day-log and strategy files (skips everything else in the folder).
+ */
+export async function gatherDigest(opts?: { days?: number; now?: Date }): Promise<string> {
+  const days = opts?.days ?? 30;
+  const now = opts?.now ?? new Date();
+
+  const names = (await listTopLevelFiles()).filter(isCorpusFile);
+  const files: CorpusFile[] = await Promise.all(
+    names.map(async (name) => ({ name, text: await readFile(name) })),
+  );
+
+  return buildDigest(files, { now, days });
+}

--- a/homebase/src/lib/reflect/primer.test.ts
+++ b/homebase/src/lib/reflect/primer.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+import { AI_PRIMER } from "./primer";
+
+// These guard against the primer drifting away from the actual folder layout.
+// If the file-naming convention changes, the digest code and this primer must
+// change together — a failure here is the reminder.
+describe("AI_PRIMER", () => {
+  it("documents the day-log and strategy file conventions", () => {
+    expect(AI_PRIMER).toContain("YYYY-MM-DD.md");
+    expect(AI_PRIMER).toContain("values.md");
+    expect(AI_PRIMER).toContain("life-goals.md");
+    expect(AI_PRIMER).toContain("year-YYYY.md");
+  });
+
+  it("sets a direct, non-flattering reflective stance", () => {
+    expect(AI_PRIMER.toLowerCase()).toContain("do not flatter");
+    expect(AI_PRIMER.toLowerCase()).toContain("private writing");
+  });
+});

--- a/homebase/src/lib/reflect/primer.ts
+++ b/homebase/src/lib/reflect/primer.ts
@@ -1,0 +1,36 @@
+// The AI primer — the single source of truth for "teach an agent my folder."
+//
+// This string is what the /integrations "Copy AI primer" button puts on the
+// clipboard, and it's the body of the distributable skill (skill/
+// homebase-reflection/SKILL.md). Keep the two in sync: if you change the file
+// layout described here, update SKILL.md too (primer.test.ts guards the file
+// conventions so a drift fails CI).
+//
+// Why it lives in code rather than a static .md the page fetches: Homebase
+// ships as a static site with no server, and bundling the string keeps the
+// copy button synchronous and offline. It's small.
+//
+// Note on voice: this is a deliberately neutral, direct default. The paid
+// Reflect chat (a later PR) will own a richer, configurable persona; this
+// primer is the free, portable baseline that works in any agent.
+
+export const AI_PRIMER = `You are helping me reflect on my own writing. The folder you can read is my Homebase: a personal journaling and planning practice kept as plain markdown files.
+
+How the folder is laid out:
+- \`YYYY-MM-DD.md\` — one file per day, my daily entries. The newest date is the most recent.
+- \`values.md\` — my core life values.
+- \`life-goals.md\` — my long-horizon goals.
+- \`year-YYYY.md\`, \`month-YYYY-MM.md\`, \`week-YYYY-Www.md\` — my intentions at each time horizon. The newest key is the current one.
+
+Read across these files and treat me as the subject. Some ways to help:
+- Read my recent daily entries and name themes or patterns I haven't named myself.
+- Hold my lived days (the dated files) up against \`values.md\` and tell me where they line up and where they drift.
+- When I say I feel stuck or unclear, read the last couple of weeks and reflect back what I actually sound like.
+- Help me turn a vague intention in a horizon file into one concrete next step.
+
+How to talk to me:
+- Be direct and specific. Cite the date or file you are drawing from.
+- Do not flatter me or soften a hard observation into mush. I am here to see clearly, not to feel good.
+- Ask me a real question when one would help more than an answer would.
+- This is my private writing. Stay with what is actually on the page; do not invent events I did not record.
+`;

--- a/homebase/src/routeTree.gen.ts
+++ b/homebase/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as NotesRouteImport } from './routes/notes'
+import { Route as IntegrationsRouteImport } from './routes/integrations'
 import { Route as DayRouteImport } from './routes/day'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WorkspaceNameRouteImport } from './routes/workspace.$name'
@@ -25,6 +26,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const NotesRoute = NotesRouteImport.update({
   id: '/notes',
   path: '/notes',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IntegrationsRoute = IntegrationsRouteImport.update({
+  id: '/integrations',
+  path: '/integrations',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DayRoute = DayRouteImport.update({
@@ -56,6 +62,7 @@ const HorizonIdRoute = HorizonIdRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/day': typeof DayRoute
+  '/integrations': typeof IntegrationsRoute
   '/notes': typeof NotesRoute
   '/settings': typeof SettingsRoute
   '/horizon/$id': typeof HorizonIdRoute
@@ -65,6 +72,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/day': typeof DayRoute
+  '/integrations': typeof IntegrationsRoute
   '/notes': typeof NotesRoute
   '/settings': typeof SettingsRoute
   '/horizon/$id': typeof HorizonIdRoute
@@ -75,6 +83,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/day': typeof DayRoute
+  '/integrations': typeof IntegrationsRoute
   '/notes': typeof NotesRoute
   '/settings': typeof SettingsRoute
   '/horizon/$id': typeof HorizonIdRoute
@@ -86,6 +95,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/day'
+    | '/integrations'
     | '/notes'
     | '/settings'
     | '/horizon/$id'
@@ -95,6 +105,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/day'
+    | '/integrations'
     | '/notes'
     | '/settings'
     | '/horizon/$id'
@@ -104,6 +115,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/day'
+    | '/integrations'
     | '/notes'
     | '/settings'
     | '/horizon/$id'
@@ -114,6 +126,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   DayRoute: typeof DayRoute
+  IntegrationsRoute: typeof IntegrationsRoute
   NotesRoute: typeof NotesRoute
   SettingsRoute: typeof SettingsRoute
   HorizonIdRoute: typeof HorizonIdRoute
@@ -135,6 +148,13 @@ declare module '@tanstack/react-router' {
       path: '/notes'
       fullPath: '/notes'
       preLoaderRoute: typeof NotesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/integrations': {
+      id: '/integrations'
+      path: '/integrations'
+      fullPath: '/integrations'
+      preLoaderRoute: typeof IntegrationsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/day': {
@@ -178,6 +198,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   DayRoute: DayRoute,
+  IntegrationsRoute: IntegrationsRoute,
   NotesRoute: NotesRoute,
   SettingsRoute: SettingsRoute,
   HorizonIdRoute: HorizonIdRoute,

--- a/homebase/src/routes/index.tsx
+++ b/homebase/src/routes/index.tsx
@@ -58,6 +58,21 @@ function StrategyAccordion() {
               >
                 Customize
               </button>
+              <button
+                type="button"
+                onClick={() => navigate({ to: "/integrations" })}
+                className="cursor-pointer border-0 bg-transparent p-0 transition-colors hover:text-[var(--ink-1)]"
+                style={{
+                  fontFamily: "var(--font-sans-ui)",
+                  fontSize: "12px",
+                  fontWeight: 600,
+                  letterSpacing: "0.16em",
+                  textTransform: "uppercase",
+                  color: "var(--ink-3)",
+                }}
+              >
+                Use with AI
+              </button>
               <FeedbackLink variant="strategic" onOpen={() => setFeedbackOpen(true)} />
             </div>
             <p

--- a/homebase/src/routes/integrations.test.tsx
+++ b/homebase/src/routes/integrations.test.tsx
@@ -1,0 +1,66 @@
+// The route component wires router + clipboard + filesystem; the presentational
+// IntegrationsContent is the exported seam we render here (same convention as
+// day.test.tsx).
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { IntegrationsContent } from "./integrations";
+
+function renderContent(overrides: Partial<Parameters<typeof IntegrationsContent>[0]> = {}) {
+  const props = {
+    onBack: vi.fn(),
+    onCopyPrimer: vi.fn(),
+    onCopyDigest: vi.fn(),
+    primerCopied: false,
+    digestCopied: false,
+    digestBusy: false,
+    digestError: null,
+    ...overrides,
+  };
+  render(<IntegrationsContent {...props} />);
+  return props;
+}
+
+describe("IntegrationsContent", () => {
+  it("explains the local-first, point-your-own-AI pitch", () => {
+    renderContent();
+    expect(screen.getByRole("heading", { name: /use your homebase with ai/i })).toBeInTheDocument();
+    // The privacy promise is the point — assert it's present.
+    expect(screen.getByText(/nothing leaves your machine/i)).toBeInTheDocument();
+  });
+
+  it("copies the primer when the primer button is clicked", () => {
+    const { onCopyPrimer } = renderContent();
+    fireEvent.click(screen.getByTestId("copy-primer"));
+    expect(onCopyPrimer).toHaveBeenCalledOnce();
+  });
+
+  it("copies the digest when the digest button is clicked", () => {
+    const { onCopyDigest } = renderContent();
+    fireEvent.click(screen.getByTestId("copy-digest"));
+    expect(onCopyDigest).toHaveBeenCalledOnce();
+  });
+
+  it("reflects the copied state on the primer button", () => {
+    renderContent({ primerCopied: true });
+    expect(screen.getByTestId("copy-primer")).toHaveTextContent(/copied/i);
+  });
+
+  it("disables the digest button and shows progress while gathering", () => {
+    renderContent({ digestBusy: true });
+    const button = screen.getByTestId("copy-digest");
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent(/gathering/i);
+  });
+
+  it("surfaces a digest error when the folder can't be read", () => {
+    renderContent({ digestError: "Couldn't read your folder just now. Try again in a moment." });
+    expect(screen.getByText(/couldn.t read your folder/i)).toBeInTheDocument();
+  });
+
+  it("navigates back when Done is clicked", () => {
+    const { onBack } = renderContent();
+    fireEvent.click(screen.getByRole("button", { name: /done/i }));
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+});

--- a/homebase/src/routes/integrations.tsx
+++ b/homebase/src/routes/integrations.tsx
@@ -1,0 +1,207 @@
+// /integrations — "use your Homebase with AI."
+//
+// The whole pitch of this page: your entries are already plain markdown in a
+// folder you control, which is the most agent-friendly format there is. So the
+// straightforward way to "ask an AI about yourself" is to point a tool you
+// already have at the folder — no account, no backend, no data leaving your
+// machine until you choose to paste it somewhere.
+//
+// Two affordances, cheapest first:
+//   1. Copy the AI primer (teaches any agent your file layout) — for tools that
+//      can read the folder directly (Claude Desktop's filesystem connector,
+//      Claude Code).
+//   2. Copy a recent digest (last 30 days + strategy files, assembled into one
+//      markdown block) — for tools that take pasted text (claude.ai, ChatGPT).
+//
+// Room: white writing-surface register (sibling of /settings), Inter Tight,
+// non-italic chrome. See CLAUDE.md "Two rooms, two registers".
+
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { gatherDigest } from "../lib/reflect/digest";
+import { AI_PRIMER } from "../lib/reflect/primer";
+
+export const Route = createFileRoute("/integrations")({
+  component: IntegrationsPage,
+});
+
+const COPIED_RESET_MS = 2000;
+
+function IntegrationsPage() {
+  const navigate = useNavigate();
+  const [primerCopied, setPrimerCopied] = useState(false);
+  const [digestCopied, setDigestCopied] = useState(false);
+  const [digestBusy, setDigestBusy] = useState(false);
+  const [digestError, setDigestError] = useState<string | null>(null);
+
+  const copyPrimer = async () => {
+    await navigator.clipboard.writeText(AI_PRIMER);
+    setPrimerCopied(true);
+    setTimeout(() => setPrimerCopied(false), COPIED_RESET_MS);
+  };
+
+  const copyDigest = async () => {
+    setDigestBusy(true);
+    setDigestError(null);
+    try {
+      const digest = await gatherDigest();
+      await navigator.clipboard.writeText(digest);
+      setDigestCopied(true);
+      setTimeout(() => setDigestCopied(false), COPIED_RESET_MS);
+    } catch {
+      setDigestError("Couldn't read your folder just now. Try again in a moment.");
+    } finally {
+      setDigestBusy(false);
+    }
+  };
+
+  return (
+    <IntegrationsContent
+      onBack={() => navigate({ to: "/" })}
+      onCopyPrimer={copyPrimer}
+      onCopyDigest={copyDigest}
+      primerCopied={primerCopied}
+      digestCopied={digestCopied}
+      digestBusy={digestBusy}
+      digestError={digestError}
+    />
+  );
+}
+
+interface IntegrationsContentProps {
+  onBack: () => void;
+  onCopyPrimer: () => void;
+  onCopyDigest: () => void;
+  primerCopied: boolean;
+  digestCopied: boolean;
+  digestBusy: boolean;
+  digestError: string | null;
+}
+
+// Presentational seam — no router, no clipboard — so it renders cleanly in tests.
+export function IntegrationsContent({
+  onBack,
+  onCopyPrimer,
+  onCopyDigest,
+  primerCopied,
+  digestCopied,
+  digestBusy,
+  digestError,
+}: IntegrationsContentProps) {
+  return (
+    <main className="min-h-screen bg-white">
+      <div className="mx-auto max-w-[640px] px-8 pb-24 pt-10">
+        <button
+          type="button"
+          onClick={onBack}
+          className="mb-10 inline-flex cursor-pointer items-center gap-3 border-0 bg-transparent p-0 py-1.5 font-sans text-[11px] font-medium uppercase text-[#6B7280] hover:text-[#111]"
+          style={{ letterSpacing: "0.24em" }}
+        >
+          <span aria-hidden="true">←</span>
+          Done
+        </button>
+
+        <h1 className="mb-3 font-sans text-[28px] font-semibold tracking-[-0.02em] text-[#111]">
+          Use your Homebase with AI
+        </h1>
+        <p className="mb-10 font-sans text-[15px] leading-relaxed text-[#4B5563]">
+          Everything you write here is plain markdown in your own folder, which happens to be the
+          easiest possible format to hand to an AI. So you don't need anything built in. You point a
+          tool you already have at your folder and ask. Nothing leaves your machine until you choose
+          to share it.
+        </p>
+
+        <Section heading="1. Reflect with an AI that can read your folder">
+          <p className="mb-3 font-sans text-[15px] leading-relaxed text-[#4B5563]">
+            Some assistants can read a local folder directly. In{" "}
+            <strong className="font-semibold text-[#111]">Claude Desktop</strong>, add the
+            filesystem connector and point it at your Homebase folder. In{" "}
+            <strong className="font-semibold text-[#111]">Claude Code</strong>, just open the folder
+            in your terminal. Then paste the primer below so it understands your files, and ask:
+          </p>
+          <ul className="mb-4 ml-5 list-disc font-sans text-[15px] leading-relaxed text-[#4B5563]">
+            <li>"Read my last 30 days and name a theme I haven't named myself."</li>
+            <li>"Hold my recent days up against my values. Where am I drifting?"</li>
+            <li>"I feel stuck. Read the last two weeks and tell me what I sound like."</li>
+          </ul>
+          <CopyButton
+            label="Copy AI primer"
+            copied={primerCopied}
+            onClick={onCopyPrimer}
+            testid="copy-primer"
+          />
+          <p className="mt-2 font-sans text-[13px] leading-relaxed text-[#9CA3AF]">
+            Tip: you can also save this primer as a file in your folder so any agent picks it up
+            automatically. Edit it to sound like the kind of reflection you actually want.
+          </p>
+        </Section>
+
+        <Section heading="2. Or paste a recent digest">
+          <p className="mb-4 font-sans text-[15px] leading-relaxed text-[#4B5563]">
+            For tools that take pasted text instead of folder access (claude.ai, ChatGPT), copy a
+            digest of your last 30 days of entries plus your strategy files as one markdown block,
+            then paste it into a new chat. It's assembled here in your browser and only goes to your
+            clipboard.
+          </p>
+          <CopyButton
+            label={digestBusy ? "Gathering…" : "Copy last 30 days"}
+            copied={digestCopied}
+            onClick={onCopyDigest}
+            disabled={digestBusy}
+            testid="copy-digest"
+          />
+          {digestError && (
+            <p className="mt-2 font-sans text-[13px] leading-relaxed text-[#B91C1C]">
+              {digestError}
+            </p>
+          )}
+        </Section>
+
+        <p
+          className="mt-16 border-t pt-5 font-sans text-[13px] leading-relaxed text-[#9CA3AF]"
+          style={{ borderColor: "#F3F4F6" }}
+        >
+          Homebase has no server and no account. These tools just make it easy to hand your own
+          writing to an assistant of your choice. Where it goes from there is up to you.
+        </p>
+      </div>
+    </main>
+  );
+}
+
+function Section({ heading, children }: { heading: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-12">
+      <h2 className="mb-3 font-sans text-[13px] font-semibold uppercase tracking-[0.14em] text-[#9CA3AF]">
+        {heading}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function CopyButton({
+  label,
+  copied,
+  onClick,
+  disabled,
+  testid,
+}: {
+  label: string;
+  copied: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+  testid: string;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={testid}
+      onClick={onClick}
+      disabled={disabled}
+      className="cursor-pointer rounded border border-[#D1D5DB] bg-white px-3 py-2 font-sans text-[14px] font-medium text-[#111] transition-colors hover:border-[#9CA3AF] disabled:cursor-default disabled:opacity-60"
+    >
+      {copied ? "Copied ✓" : label}
+    </button>
+  );
+}

--- a/skill/homebase-reflection/SKILL.md
+++ b/skill/homebase-reflection/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: homebase-reflection
+description: Reflect on a Homebase journaling folder — read the daily entries and strategy files, surface patterns the writer hasn't named, and check lived days against stated values. Use when the user points you at a folder of YYYY-MM-DD.md day files plus values.md / life-goals.md / year-/month-/week- strategy files and wants introspection, values-alignment, or honest pattern-finding over their own writing.
+---
+
+# Homebase reflection
+
+[Homebase](https://github.com/meninoebom/homebase) is a personal journaling and
+planning practice stored as plain markdown in a single folder the writer owns.
+Because it's plain markdown, any agent that can read the folder can help the
+writer reflect. This skill teaches you the layout and the stance.
+
+It's portable: the same instructions work in Claude Code (open the folder in
+your terminal), Claude Desktop (filesystem connector pointed at the folder), or
+any other tool with local file access. There is no API and no server — the files
+on disk are the whole interface.
+
+## How the folder is laid out
+
+- `YYYY-MM-DD.md` — one file per day, the daily entries. The newest date is the
+  most recent. These are the lived record.
+- `values.md` — the writer's core life values.
+- `life-goals.md` — long-horizon goals.
+- `year-YYYY.md`, `month-YYYY-MM.md`, `week-YYYY-Www.md` — intentions at each
+  time horizon. The newest key is the current period.
+
+Other files may exist (a `homebase.config.json`, per-slot subfolders). Ignore
+them unless asked; the markdown above is the corpus.
+
+## What to do
+
+Read across the daily entries and the strategy files, and treat the writer as
+the subject. Useful moves:
+
+- Read the recent daily entries and name a theme or pattern the writer hasn't
+  named themselves.
+- Hold the lived days (dated files) up against `values.md` and report where they
+  line up and where they drift.
+- When the writer says they feel stuck or unclear, read the last couple of weeks
+  and reflect back what they actually sound like.
+- Help turn a vague intention in a horizon file into one concrete next step.
+
+## How to talk to them
+
+- Be direct and specific. Cite the date or file you're drawing from.
+- Don't flatter or soften a hard observation into mush. The point is to see
+  clearly, not to feel good.
+- Ask a real question when one would help more than an answer would.
+- This is private writing. Stay with what's actually on the page; don't invent
+  events that weren't recorded.
+
+## A good starting prompt
+
+> Read my Homebase folder: my daily `YYYY-MM-DD.md` entries from the last month,
+> plus `values.md` and my year/month/week files. Don't summarize them back to
+> me. Tell me one pattern I'm not seeing, and one place my days are drifting from
+> my values. Be direct.


### PR DESCRIPTION
## What & why

We have a folder full of the user's own writing in plain markdown. That's already the most agent-friendly format there is, so the simplest, most on-brand way to let people "ask an AI about themselves" is to point a tool they already have at their folder. No backend, no account, nothing leaves the device until they choose to paste it. This is **stage 1** of the Reflect direction (stage 2 is the opt-in in-app bring-your-own-bot chat).

## What's in this PR

- **`/integrations` page** (gated, white utility register, sibling of `/settings`) with two affordances:
  - **Copy AI primer** — puts a primer on the clipboard that teaches any local agent the folder layout and a direct, non-flattering reflective stance.
  - **Copy last 30 days** — assembles recent day files + strategy files into one markdown block on the clipboard, for tools that take pasted text (claude.ai, ChatGPT).
- **`src/lib/reflect/`**
  - `primer.ts` — `AI_PRIMER`, the single source of truth for the copy button and the skill.
  - `digest.ts` — pure `buildDigest()` assembler (deterministic, `now` injected) + thin `gatherDigest()` fs wrapper. Only reads day-log and strategy files.
- **`skill/homebase-reflection/SKILL.md`** — a portable reflection skill, drop-in for Claude Code / Claude Desktop / any agent with local file access.
- **"Use with AI"** footer link on `/`, and a **ROADMAP** entry.

## Privacy posture

The digest is assembled entirely in the browser and only ever reaches the clipboard. Nothing is sent anywhere. Where it goes next is the user's choice. Matches the local-first, no-backend promise.

## Tests

- `digest.test.ts` — file classification, window math (today through day-29 in, day-30 out), newest-first ordering, empty-file skipping.
- `primer.test.ts` — guards the primer against drifting from the actual file conventions.
- `integrations.test.tsx` — renders the presentational seam, asserts the pitch + privacy line, copy callbacks, busy/error/copied states.

All 223 tests pass; `vp check` clean.

## Notes for review

- `/integrations` sits behind `SetupGate` like every route now does (the old public `/about` escape was removed in the sotol-fishhook redesign). That's correct here: "Copy last 30 days" needs folder access anyway.
- The default primer is a deliberately neutral baseline. The richer, configurable reflection *persona* is owned by stage 2's chat, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)